### PR TITLE
Add very basic Fortran source sanitisation

### DIFF
--- a/source/fab/__main__.py
+++ b/source/fab/__main__.py
@@ -9,8 +9,15 @@ Command-line interface to Fab build tool.
 import argparse
 import logging
 import sys
+import os
 
 import fab
+from fab.language.fortran import reader
+
+_extensions = [
+    'F90',
+    'f90',
+    ]
 
 
 def parse_cli() -> argparse.Namespace:
@@ -27,7 +34,19 @@ def parse_cli() -> argparse.Namespace:
                         help='Print version identifier and exit')
     parser.add_argument('-v', '--verbose', action='store_true',
                         help='Produce a running commentary on progress')
+    parser.add_argument('source',
+                        help='The path to the source tree to build')
     return parser.parse_args()
+
+
+def sourcepath_iter(rootpath: str) -> str:
+    '''
+    Return files we can process from the source tree.
+    '''
+    for root, _, files in os.walk(rootpath):
+        for name in files:
+            if name.split(".")[-1] in _extensions:
+                yield os.path.join(root, name)
 
 
 def main() -> None:
@@ -43,3 +62,8 @@ def main() -> None:
         logger.setLevel(logging.INFO)
     else:
         logger.setLevel(logging.WARNING)
+
+    for sourcefile in sourcepath_iter(arguments.source):
+        print(f'Processing {sourcefile}:')
+        print(''.join(reader.sourcefile_iter(sourcefile)))
+        print(f'Processed {sourcefile}\n')

--- a/source/fab/__main__.py
+++ b/source/fab/__main__.py
@@ -36,7 +36,7 @@ def parse_cli() -> argparse.Namespace:
     parser.add_argument('-v', '--verbose', action='store_true',
                         help='Produce a running commentary on progress')
     parser.add_argument('source',
-                        help='The path to the source tree to build')
+                        help='The path of the source tree to build')
     return parser.parse_args()
 
 

--- a/source/fab/__main__.py
+++ b/source/fab/__main__.py
@@ -64,6 +64,7 @@ def main() -> None:
         logger.setLevel(logging.WARNING)
 
     for sourcefile in sourcepath_iter(arguments.source):
-        print(f'Processing {sourcefile}:')
-        print(''.join(reader.sourcefile_iter(sourcefile)))
-        print(f'Processed {sourcefile}\n')
+        msg = '{0:s}\n! {1:s}\n{0:s}'
+        print(msg.format("!" + "#" * (len(sourcefile)+1),
+                         sourcefile))
+        print('\n'.join(reader.sourcefile_iter(sourcefile)))

--- a/source/fab/language/fortran/reader.py
+++ b/source/fab/language/fortran/reader.py
@@ -13,22 +13,21 @@ from pathlib import Path
 def sourcefile_iter(filepath: Path) -> Generator[str, None, None]:
     '''
     Generator to return each line of a source file; the lines
-    are sanitised to remove strings and comments, as well as
-    collapsing the result of continuation lines and trimming
-    away as much whitespace as possible
+    are sanitised to remove comments and collapse the result
+    of continuation lines whilst also trimming away as much
+    whitespace as possible
     '''
     with filepath.open('r') as source:
         line_buffer = ''
         for line in source:
-            # Remove strings - the pattern is designed so that it
-            # remembers the opening quotation type and then matches
-            # for its pair, ignoring any that are explicitly escaped
-            line = re.sub(r'(\'|").*?(?<!\\)\1', r'\1\1', line)
 
-            # Remove comments
+            # Remove comments - we accept that an exclamation mark
+            # appearing in a string will cause the rest of that line
+            # to be blanked out, but the things we wish to parse
+            # later shouldn't appear after a string on a line anyway
             line = re.sub(r'!.*', '', line)
 
-            # If the line is now empty, go onto the next
+            # If the line is empty, go onto the next
             if line.strip() == '':
                 continue
 

--- a/source/fab/language/fortran/reader.py
+++ b/source/fab/language/fortran/reader.py
@@ -1,0 +1,34 @@
+# (c) Crown copyright Met Office. All rights reserved.
+# For further details please refer to the file COPYRIGHT
+# which you should have received as part of this distribution
+
+'''
+Source reading tools for Fortran format.
+'''
+import re
+
+
+def sourcefile_iter(filename: str) -> str:
+    '''
+    Generator to return each line of a source file; the lines
+    are sanitised to remove strings and comments, as well as
+    collapsing the result of continuation lines.
+    '''
+    with open(filename, 'r') as sourcefile:
+        line_buffer = ''
+        for line in sourcefile:
+            # Remove strings - the pattern is designed so that it
+            # remembers the opening quotation type and then matches
+            # for its pair, ignoring any that are explicitly escaped
+            line = re.sub(r'(\'|").*?(?<!\\)\1', '', line)
+
+            # Remove comments
+            line = re.sub(r'!.*', '', line)
+
+            # Deal with continuations
+            line_buffer += line
+            if "&" in line_buffer:
+                line_buffer = re.sub(r'&\s*\n', '', line_buffer)
+            else:
+                yield line_buffer
+                line_buffer = ''

--- a/source/fab/language/fortran/reader.py
+++ b/source/fab/language/fortran/reader.py
@@ -6,18 +6,20 @@
 Source reading tools for Fortran format.
 '''
 import re
+from typing import Generator
+from pathlib import Path
 
 
-def sourcefile_iter(filename: str) -> str:
+def sourcefile_iter(filepath: Path) -> Generator[str, None, None]:
     '''
     Generator to return each line of a source file; the lines
     are sanitised to remove strings and comments, as well as
     collapsing the result of continuation lines and trimming
     away as much whitespace as possible
     '''
-    with open(filename, 'r') as sourcefile:
+    with filepath.open('r') as source:
         line_buffer = ''
-        for line in sourcefile:
+        for line in source:
             # Remove strings - the pattern is designed so that it
             # remembers the opening quotation type and then matches
             # for its pair, ignoring any that are explicitly escaped


### PR DESCRIPTION
This is really just to give us some very basic functionality that we can use as a base to think about putting in the various testing workflows that we want to have.  It adds a method for going through the source of a (Fortran) file but with a bit of cleaning to try and give the subsequent parsing steps we'll want to do an easier time.

I'm unsure about what kind of structure we will eventually want in terms of language-specific stuff so for now I've assumed we might compartmentalise things via `fab.language.<language_name>` but in time I expect this to change.  Currently `fab` just spits out the sanitised source in full, so at least you can tell it's doing something!