### PR TITLE
Add reference to readme about command line interface and fix the workflow

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -1,6 +1,6 @@
 name: Python package
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -18,3 +18,9 @@ The software is made available under a 3-clause BSD licence.
 ## Installation
 
 You may simply use `pip install sci-fab`.
+
+## Usage
+
+Although Fab is in its initial development phases right now and much of the
+functionality is yet to be added, the command line interface to the tool is 
+in place and can be run using the command `fab` 


### PR DESCRIPTION
This is mostly being done to confirm a theory about the reason why our actions aren't running on `metomi/fab` - namely that since we modified the repository settings _during_ the other PRs which were raised that has somehow put them into a broken state.  Since this PR is being created _after_ the changes perhaps it will work correclty