### PR TITLE
Calculate a hash for each file as it is being analysed.

### DIFF
--- a/source/fab/application.py
+++ b/source/fab/application.py
@@ -6,7 +6,7 @@
 from pathlib import Path
 from typing import Dict, Mapping, Type
 
-from fab.database import StateDatabase
+from fab.database import SqliteStateDatabase
 from fab.language import Analyser
 from fab.language.fortran import FortranAnalyser, FortranWorkingState
 from fab.source_tree import TreeDescent, ExtensionVisitor
@@ -19,7 +19,7 @@ class Fab(object):
     }
 
     def __init__(self, workspace: Path):
-        self._state = StateDatabase(workspace)
+        self._state = SqliteStateDatabase(workspace)
         self._extension_map: Mapping[str, Analyser] \
             = {extension: analyser(self._state)
                for extension, analyser in self._extensions.items()}

--- a/source/fab/application.py
+++ b/source/fab/application.py
@@ -9,7 +9,7 @@ from typing import Dict, Mapping, Type
 from fab.database import SqliteStateDatabase
 from fab.language import Analyser
 from fab.language.fortran import FortranAnalyser, FortranWorkingState
-from fab.source_tree import TreeDescent, ExtensionVisitor
+from fab.source_tree import ExtensionVisitor, FileInfoDatabase, TreeDescent
 
 
 class Fab(object):
@@ -29,9 +29,15 @@ class Fab(object):
         descender = TreeDescent(source)
         descender.descend(visitor)
 
-        db = FortranWorkingState(self._state)
-        for unit, files in db.iterate_program_units():
+        file_db = FileInfoDatabase(self._state)
+        for file in file_db.get_all_filenames():
+            info = file_db.get_file_info(file)
+            print(info.filename)
+            print(f'    hash: {info.adler32}')
+
+        fortran_db = FortranWorkingState(self._state)
+        for unit, files in fortran_db.iterate_program_units():
             print(unit)
             for filename in files:
                 print('    found in: ' + str(filename))
-                print('    depends on: ' + str(db.depends_on(unit)))
+                print('    depends on: ' + str(fortran_db.depends_on(unit)))

--- a/source/fab/database.py
+++ b/source/fab/database.py
@@ -44,7 +44,7 @@ class StateDatabase(ABC):
     @abstractmethod
     def execute(self, query: Union[Sequence[str], str],
                 inserts: Dict[str, str]) -> DatabaseRows:
-        raise NotImplementedError('Abstract methods must be overridden.')
+        raise NotImplementedError('Abstract methods must be implemented.')
 
 
 class DatabaseDecorator(StateDatabase):
@@ -62,7 +62,7 @@ class FileInfoDatabase(DatabaseDecorator):
     # By way of example, Linux systems often define this value to be 4k.
     #
     # Given that we will often be working with Linux systems I have followed
-    # suite.
+    # suit.
     #
     PATH_LENGTH = 1024 * 4
 

--- a/source/fab/database.py
+++ b/source/fab/database.py
@@ -86,6 +86,12 @@ class FileInfoDatabase(DatabaseDecorator):
                      {'filename': str(filename),
                       'adler32': str(adler32)})
 
+    def get_all_filenames(self) -> Iterator[Path]:
+        query = ['select filename from file_info order by filename']
+        rows: DatabaseRows = self.execute(query, {})
+        for row in rows:
+            yield Path(row['filename'])
+
     def get_file_info(self, filename: Path) -> FileInfo:
         queries = ['''select filename, adler32 from file_info
                           where filename=:filename''']

--- a/source/fab/database.py
+++ b/source/fab/database.py
@@ -14,6 +14,16 @@ class WorkingStateException(Exception):
     pass
 
 
+class FileInfo(object):
+    def __init__(self, filename: Path, adler32: int):
+        self.filename = filename
+        self.adler32 = adler32
+
+    def __eq__(self, other):
+        return (str(other.filename) == str(self.filename)) \
+               and (other.adler32 == self.adler32)
+
+
 class StateDatabase(object):
     '''
     Provides a semi-permanent store of working state.
@@ -21,6 +31,15 @@ class StateDatabase(object):
     Backed by a database which may be deleted at any point. It should not be
     used for permanent storage of e.g. configuration.
     '''
+    # The Posix standard specifies a value PATH_MAX but requires only that it
+    # be greater than 256. Obviously this is too little for modern systems.
+    # By way of example, Linux systems often define this value to be 4k.
+    #
+    # Given that we will often be working with Linux systems I have followed
+    # suite.
+    #
+    _PATH_LENGTH = 1024 * 4
+
     def __init__(self, working_directory: Path):
         self._working_directory: Path = working_directory
 
@@ -31,5 +50,38 @@ class StateDatabase(object):
             = sqlite3.connect(str(working_directory / 'state.db'))
         self.connection.row_factory = sqlite3.Row
 
+        self.connection.execute(
+            '''create table if not exists file_info (
+                 id integer primary key,
+                 filename character({filename}) not null,
+                 adler32 integer not null
+               )'''.format(filename=self._PATH_LENGTH)
+        )
+        self.connection.execute(
+            'create index if not exists idx_file_info_adler32 '
+            'on file_info(adler32)')
+        self.connection.commit()
+
     def __del__(self):
         self.connection.close()
+
+    def add_file_info(self, filename: Path, adler32: int) -> None:
+        self.connection.execute(
+            'delete from file_info where filename=:filename',
+            {'filename': str(filename)})
+        self.connection.execute(
+            '''insert into file_info (filename, adler32)
+            values (:filename, :adler32)''',
+            {'filename': str(filename), 'adler32': adler32})
+        self.connection.commit()
+
+    def get_file_info(self, filename: Path) -> FileInfo:
+        cursor: sqlite3.Cursor = self.connection.execute(
+            '''select filename, adler32 from file_info
+            where filename=:filename''',
+            {'filename': str(filename)})
+        row: sqlite3.Row = cursor.fetchone()
+        if row is None:
+            raise WorkingStateException('File information not found for: '
+                                        + str(filename))
+        return FileInfo(row['filename'], row['adler32'])

--- a/source/fab/database.py
+++ b/source/fab/database.py
@@ -6,8 +6,10 @@
 '''
 Working state which is either per-build or persistent between builds.
 '''
-import sqlite3
+from abc import ABC, abstractmethod
 from pathlib import Path
+import sqlite3
+from typing import Dict, Iterator, Optional, Sequence, Union
 
 
 class WorkingStateException(Exception):
@@ -24,13 +26,37 @@ class FileInfo(object):
                and (other.adler32 == self.adler32)
 
 
-class StateDatabase(object):
-    '''
-    Provides a semi-permanent store of working state.
+class DatabaseRows(Iterator[Dict[str, str]]):
+    def __init__(self, cursor: Optional[sqlite3.Cursor]):
+        self._cursor = cursor
 
-    Backed by a database which may be deleted at any point. It should not be
-    used for permanent storage of e.g. configuration.
-    '''
+    def __next__(self) -> Dict[str, str]:
+        if self._cursor is None:
+            raise StopIteration()
+        row = self._cursor.fetchone()
+        if row is None:
+            raise StopIteration()
+        else:
+            return row
+
+
+class StateDatabase(ABC):
+    @abstractmethod
+    def execute(self, query: Union[Sequence[str], str],
+                inserts: Dict[str, str]) -> DatabaseRows:
+        raise NotImplementedError('Abstract methods must be overridden.')
+
+
+class DatabaseDecorator(StateDatabase):
+    def __init__(self, database: StateDatabase):
+        self._database: StateDatabase = database
+
+    def execute(self, query: Union[Sequence[str], str],
+                inserts: Dict[str, str]) -> DatabaseRows:
+        return self._database.execute(query, inserts)
+
+
+class FileInfoDatabase(DatabaseDecorator):
     # The Posix standard specifies a value PATH_MAX but requires only that it
     # be greater than 256. Obviously this is too little for modern systems.
     # By way of example, Linux systems often define this value to be 4k.
@@ -38,50 +64,71 @@ class StateDatabase(object):
     # Given that we will often be working with Linux systems I have followed
     # suite.
     #
-    _PATH_LENGTH = 1024 * 4
+    PATH_LENGTH = 1024 * 4
 
+    def __init__(self, database: StateDatabase):
+        super().__init__(database)
+
+        queries = ['''create table if not exists file_info (
+                          id integer primary key,
+                          filename character({filename_length}) not null,
+                          adler32 integer not null
+                          )'''.format(filename_length=self.PATH_LENGTH),
+                   '''create index if not exists idx_file_info_adler32
+                          on file_info(adler32)''']
+        self.execute(queries, {})
+
+    def add_file_info(self, filename: Path, adler32: int) -> None:
+        queries = ['delete from file_info where filename=:filename',
+                   '''insert into file_info (filename, adler32)
+                         values (:filename, :adler32)''']
+        self.execute(queries,
+                     {'filename': str(filename),
+                      'adler32': str(adler32)})
+
+    def get_file_info(self, filename: Path) -> FileInfo:
+        queries = ['''select filename, adler32 from file_info
+                          where filename=:filename''']
+        rows: DatabaseRows = self.execute(queries,
+                                          {'filename': str(filename)})
+        try:
+            row = next(rows)
+            return FileInfo(Path(row['filename']), int(row['adler32']))
+        except StopIteration:
+            raise WorkingStateException('File information not found for: '
+                                        + str(filename))
+
+
+class SqliteStateDatabase(StateDatabase):
+    '''
+    Provides a semi-permanent store of working state.
+
+    Backed by a database which may be deleted at any point. It should not be
+    used for permanent storage of e.g. configuration.
+    '''
     def __init__(self, working_directory: Path):
         self._working_directory: Path = working_directory
 
         if not self._working_directory.exists():
             self._working_directory.mkdir(parents=True)
 
-        self.connection: sqlite3.Connection \
+        self._connection: sqlite3.Connection \
             = sqlite3.connect(str(working_directory / 'state.db'))
-        self.connection.row_factory = sqlite3.Row
-
-        self.connection.execute(
-            '''create table if not exists file_info (
-                 id integer primary key,
-                 filename character({filename}) not null,
-                 adler32 integer not null
-               )'''.format(filename=self._PATH_LENGTH)
-        )
-        self.connection.execute(
-            'create index if not exists idx_file_info_adler32 '
-            'on file_info(adler32)')
-        self.connection.commit()
+        self._connection.row_factory = sqlite3.Row
 
     def __del__(self):
-        self.connection.close()
+        self._connection.close()
 
-    def add_file_info(self, filename: Path, adler32: int) -> None:
-        self.connection.execute(
-            'delete from file_info where filename=:filename',
-            {'filename': str(filename)})
-        self.connection.execute(
-            '''insert into file_info (filename, adler32)
-            values (:filename, :adler32)''',
-            {'filename': str(filename), 'adler32': adler32})
-        self.connection.commit()
+    def execute(self, query: Union[Sequence[str], str],
+                inserts: Dict[str, str]) -> DatabaseRows:
+        if isinstance(query, str):
+            query_list: Sequence[str] = [query]
+        else:
+            query_list = query
 
-    def get_file_info(self, filename: Path) -> FileInfo:
-        cursor: sqlite3.Cursor = self.connection.execute(
-            '''select filename, adler32 from file_info
-            where filename=:filename''',
-            {'filename': str(filename)})
-        row: sqlite3.Row = cursor.fetchone()
-        if row is None:
-            raise WorkingStateException('File information not found for: '
-                                        + str(filename))
-        return FileInfo(row['filename'], row['adler32'])
+        cursor = None
+        for command in query_list:
+            cursor = self._connection.execute(command, inserts)
+        self._connection.commit()
+
+        return DatabaseRows(cursor)

--- a/source/fab/language/__init__.py
+++ b/source/fab/language/__init__.py
@@ -18,7 +18,8 @@ class Analyser(ABC):
     def __init__(self, database: SqliteStateDatabase):
         self._database = database
 
-    def get_database(self):
+    @property
+    def database(self):
         return self._database
 
     @abstractmethod

--- a/source/fab/language/__init__.py
+++ b/source/fab/language/__init__.py
@@ -7,7 +7,7 @@ Modules for handling different program languages appear in this package.
 from abc import ABC, abstractmethod
 from pathlib import Path
 
-from fab.database import StateDatabase
+from fab.database import SqliteStateDatabase
 
 
 class AnalysisException(Exception):
@@ -15,7 +15,7 @@ class AnalysisException(Exception):
 
 
 class Analyser(ABC):
-    def __init__(self, database: StateDatabase):
+    def __init__(self, database: SqliteStateDatabase):
         self._database = database
 
     @abstractmethod

--- a/source/fab/language/__init__.py
+++ b/source/fab/language/__init__.py
@@ -5,9 +5,9 @@
 Modules for handling different program languages appear in this package.
 '''
 from abc import ABC, abstractmethod
-from pathlib import Path
 
 from fab.database import SqliteStateDatabase
+from fab.reader import TextReader
 
 
 class AnalysisException(Exception):
@@ -18,6 +18,9 @@ class Analyser(ABC):
     def __init__(self, database: SqliteStateDatabase):
         self._database = database
 
+    def get_database(self):
+        return self._database
+
     @abstractmethod
-    def analyse(self, filename: Path) -> None:
+    def analyse(self, file: TextReader) -> None:
         raise NotImplementedError('Abstract methods must be implemented')

--- a/source/fab/language/fortran.py
+++ b/source/fab/language/fortran.py
@@ -9,6 +9,7 @@ import logging
 from pathlib import Path
 import re
 from typing import (Generator,
+                    Iterator,
                     List,
                     Match,
                     Optional,
@@ -23,7 +24,7 @@ from fab.database import (DatabaseDecorator,
                           SqliteStateDatabase,
                           WorkingStateException)
 from fab.language import Analyser, AnalysisException
-from fab.reader import TextReader
+from fab.reader import TextReader, TextReaderDecorator
 
 
 class FortranWorkingState(DatabaseDecorator):
@@ -196,6 +197,44 @@ class FortranWorkingState(DatabaseDecorator):
         return units
 
 
+class _FortranNormaliser(TextReaderDecorator):
+    def __init__(self, source: TextReader):
+        super().__init__(source)
+        self._line_buffer = ''
+
+    def line_by_line(self) -> Iterator[str]:
+        '''
+        Each line of the source file is modified to ease the work of analysis.
+
+        The lines are sanitised to remove comments and collapse the result
+        of continuation lines whilst also trimming away as much whitespace as
+        possible
+        '''
+        for line in self._source.line_by_line():
+            # Remove comments - we accept that an exclamation mark
+            # appearing in a string will cause the rest of that line
+            # to be blanked out, but the things we wish to parse
+            # later shouldn't appear after a string on a line anyway
+            line = re.sub(r'!.*', '', line)
+
+            # If the line is empty, go onto the next
+            if line.strip() == '':
+                continue
+
+            # Deal with continuations by removing them to collapse
+            # the lines together
+            self._line_buffer += line
+            if "&" in self._line_buffer:
+                self._line_buffer = re.sub(r'&\s*\n', '', self._line_buffer)
+                continue
+
+            # Before output, minimise whitespace but add a space on the end
+            # of the line.
+            line_buffer = re.sub(r'\s+', r' ', self._line_buffer)
+            yield line_buffer.rstrip()
+            self._line_buffer = ''
+
+
 class FortranAnalyser(Analyser):
     def __init__(self, database: SqliteStateDatabase):
         super().__init__(database)
@@ -258,8 +297,9 @@ class FortranAnalyser(Analyser):
 
         self._state.remove_fortran_file(source.get_filename())
 
+        normalised_source = _FortranNormaliser(source)
         scope: List[Tuple[str, str]] = []
-        for line in self._normalise(source):
+        for line in normalised_source.line_by_line():
             logger.debug(scope)
             logger.debug('Considering: %s', line)
 
@@ -355,36 +395,3 @@ class FortranAnalyser(Analyser):
                                       'found': end_name}
                         raise AnalysisException(
                             end_message.format(**end_values))
-
-    @staticmethod
-    def _normalise(source: TextReader) -> Generator[str, None, None]:
-        '''
-        Generator to return each line of a source file; the lines
-        are sanitised to remove comments and collapse the result
-        of continuation lines whilst also trimming away as much
-        whitespace as possible
-        '''
-        line_buffer = ''
-        for line in source.line_by_line():
-            # Remove comments - we accept that an exclamation mark
-            # appearing in a string will cause the rest of that line
-            # to be blanked out, but the things we wish to parse
-            # later shouldn't appear after a string on a line anyway
-            line = re.sub(r'!.*', '', line)
-
-            # If the line is empty, go onto the next
-            if line.strip() == '':
-                continue
-
-            # Deal with continuations by removing them to collapse
-            # the lines together
-            line_buffer += line
-            if "&" in line_buffer:
-                line_buffer = re.sub(r'&\s*\n', '', line_buffer)
-                continue
-
-            # Before output, minimise whitespace but add a space on the end
-            # of the line.
-            line_buffer = re.sub(r'\s+', r' ', line_buffer)
-            yield line_buffer.rstrip()
-            line_buffer = ''

--- a/source/fab/language/fortran.py
+++ b/source/fab/language/fortran.py
@@ -29,15 +29,13 @@ class FortranWorkingState(object):
 
     def __init__(self, database: StateDatabase):
         self._database: StateDatabase = database
-        # Choosing a length for filenames is much less clear cut than for
-        # labels. I have gone for 1k.
-        #
         self._database.connection.execute(
             '''create table if not exists fortran_unit (
                  id integer primary key,
                  unit character({label}) not null,
-                 filename character(1024) not null
-               )'''.format(label=self._FORTRAN_LABEL_LENGTH)
+                 filename character({filename}) not null
+               )'''.format(label=self._FORTRAN_LABEL_LENGTH,
+                           filename=database._PATH_LENGTH)
         )
         self._database.connection.execute(
             'create index if not exists idx_fortran_program_unit '

--- a/source/fab/language/fortran.py
+++ b/source/fab/language/fortran.py
@@ -295,7 +295,7 @@ class FortranAnalyser(Analyser):
     def analyse(self, source: TextReader) -> None:
         logger = logging.getLogger(__name__)
 
-        self._state.remove_fortran_file(source.get_filename())
+        self._state.remove_fortran_file(source.filename)
 
         normalised_source = _FortranNormaliser(source)
         scope: List[Tuple[str, str]] = []
@@ -311,7 +311,7 @@ class FortranAnalyser(Analyser):
                     unit_name: str = unit_match.group(2).lower()
                     logger.debug('Found %s called "%s"', unit_type, unit_name)
                     self._state.add_fortran_program_unit(unit_name,
-                                                         source.get_filename())
+                                                         source.filename)
                     scope.append((unit_type, unit_name))
                     continue
 

--- a/source/fab/reader.py
+++ b/source/fab/reader.py
@@ -7,7 +7,7 @@ from zlib import adler32
 class TextReader(ABC):
     @abstractmethod
     def get_filename(self) -> Union[Path, str]:
-        raise NotImplementedError('Abstract method must be implmeneted')
+        raise NotImplementedError('Abstract method must be implemented')
 
     @abstractmethod
     def line_by_line(self) -> Iterator[str]:

--- a/source/fab/reader.py
+++ b/source/fab/reader.py
@@ -1,0 +1,65 @@
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import IO, Iterator, List, Text, Union
+from zlib import adler32
+
+
+class TextReader(ABC):
+    @abstractmethod
+    def get_filename(self) -> Union[Path, str]:
+        raise NotImplementedError('Abstract method must be implmeneted')
+
+    @abstractmethod
+    def line_by_line(self) -> Iterator[str]:
+        raise NotImplementedError('Abstract method must be implemented')
+
+
+class FileTextReader(TextReader):
+    def __init__(self, filename: Path):
+        self._filename: Path = filename
+        self._handle: IO[Text] = self._filename.open(encoding='utf-8')
+
+    def __del__(self):
+        self._handle.close()
+
+    def get_filename(self):
+        return self._filename
+
+    def line_by_line(self):
+        for line in self._handle.readlines():
+            yield line
+
+
+class StringTextReader(TextReader):
+    def __init__(self, string: str):
+        self._hash = hash(string)
+        self._content: List[str] = string.splitlines(keepends=True)
+
+    def get_filename(self):
+        return f'[string:{hash(self._hash)}]'
+
+    def line_by_line(self):
+        while len(self._content) > 0:
+            yield self._content.pop(0)
+
+
+class TextReaderDecorator(TextReader, ABC):
+    def __init__(self, reader: TextReader):
+        self._source = reader
+
+    def get_filename(self):
+        return self._source.get_filename()
+
+
+class TextReaderAdler32(TextReaderDecorator):
+    def __init__(self, source: TextReader):
+        super().__init__(source)
+        self._hash = 1
+
+    def get_hash(self):
+        return self._hash
+
+    def line_by_line(self):
+        for line in self._source.line_by_line():
+            self._hash = adler32(bytes(line, encoding='utf-8'), self._hash)
+            yield(line)

--- a/source/fab/reader.py
+++ b/source/fab/reader.py
@@ -5,8 +5,9 @@ from zlib import adler32
 
 
 class TextReader(ABC):
+    @property
     @abstractmethod
-    def get_filename(self) -> Union[Path, str]:
+    def filename(self) -> Union[Path, str]:
         raise NotImplementedError('Abstract method must be implemented')
 
     @abstractmethod
@@ -22,7 +23,8 @@ class FileTextReader(TextReader):
     def __del__(self):
         self._handle.close()
 
-    def get_filename(self):
+    @property
+    def filename(self):
         return self._filename
 
     def line_by_line(self):
@@ -35,7 +37,8 @@ class StringTextReader(TextReader):
         self._hash = hash(string)
         self._content: List[str] = string.splitlines(keepends=True)
 
-    def get_filename(self):
+    @property
+    def filename(self):
         return f'[string:{hash(self._hash)}]'
 
     def line_by_line(self):
@@ -47,8 +50,9 @@ class TextReaderDecorator(TextReader, ABC):
     def __init__(self, reader: TextReader):
         self._source = reader
 
-    def get_filename(self):
-        return self._source.get_filename()
+    @property
+    def filename(self):
+        return self._source.filename
 
 
 class TextReaderAdler32(TextReaderDecorator):
@@ -56,10 +60,11 @@ class TextReaderAdler32(TextReaderDecorator):
         super().__init__(source)
         self._hash = 1
 
-    def get_hash(self):
+    @property
+    def hash(self):
         return self._hash
 
     def line_by_line(self):
         for line in self._source.line_by_line():
             self._hash = adler32(bytes(line, encoding='utf-8'), self._hash)
-            yield(line)
+            yield line

--- a/source/fab/source_tree.py
+++ b/source/fab/source_tree.py
@@ -34,7 +34,7 @@ class ExtensionVisitor(TreeVisitor):
             for _ in hasher.line_by_line():
                 pass  # Make sure we've read the whole file.
             file_info = FileInfoDatabase(analyser.database)
-            file_info.add_file_info(candidate, hasher.get_hash())
+            file_info.add_file_info(candidate, hasher.hash)
         except KeyError:
             pass
 

--- a/source/fab/source_tree.py
+++ b/source/fab/source_tree.py
@@ -33,7 +33,7 @@ class ExtensionVisitor(TreeVisitor):
             analyser.analyse(hasher)
             for _ in hasher.line_by_line():
                 pass  # Make sure we've read the whole file.
-            file_info = FileInfoDatabase(analyser.get_database())
+            file_info = FileInfoDatabase(analyser.database)
             file_info.add_file_info(candidate, hasher.get_hash())
         except KeyError:
             pass

--- a/system-tests/FortranDependencies/expected.txt
+++ b/system-tests/FortranDependencies/expected.txt
@@ -1,3 +1,11 @@
+system-tests/FortranDependencies/bye_mod.f90
+    hash: 2054258567
+system-tests/FortranDependencies/first.f90
+    hash: 1577883012
+system-tests/FortranDependencies/greeting_mod.f90
+    hash: 1789892039
+system-tests/FortranDependencies/second.f90
+    hash: 624596557
 bye_mod
     found in: system-tests/FortranDependencies/bye_mod.f90
     depends on: ['constants_mod']

--- a/system-tests/MinimalFortran/expected.txt
+++ b/system-tests/MinimalFortran/expected.txt
@@ -1,3 +1,5 @@
+system-tests/MinimalFortran/program.f90
+    hash: 779717536
 test
     found in: system-tests/MinimalFortran/program.f90
     depends on: []

--- a/system-tests/test.py
+++ b/system-tests/test.py
@@ -40,11 +40,11 @@ class FabTestCase(systest.TestCase):
     def setup(self):
         working_dir: Path = self._test_directory / 'working'
         if working_dir.is_dir():
-            shutil.rmtree(working_dir)
+            shutil.rmtree(str(working_dir))
 
     def teardown(self):
         working_dir: Path = self._test_directory / 'working'
-        shutil.rmtree(working_dir)
+        shutil.rmtree(str(working_dir))
 
     def run(self):
         command = ['python3', '-m', 'fab', self._test_directory]

--- a/unit-tests/database_test.py
+++ b/unit-tests/database_test.py
@@ -3,3 +3,31 @@
 # For further details please refer to the file COPYRIGHT
 # which you should have received as part of this distribution
 ##############################################################################
+from pathlib import Path
+import pytest  # type: ignore
+
+from fab.database import StateDatabase, FileInfo, WorkingStateException
+
+
+class TestStateDatabase(object):
+    def test_file_info(self, tmp_path: Path):
+        test_unit = StateDatabase(tmp_path)
+
+        with pytest.raises(WorkingStateException):
+            test_unit.get_file_info(Path('foo.f90'))
+
+        test_unit.add_file_info(Path('foo.f90'), 1234)
+        assert test_unit.get_file_info(Path('foo.f90')) \
+            == FileInfo(Path('foo.f90'), 1234)
+
+        test_unit.add_file_info(Path('bar/baz.f90'), 5786)
+        assert test_unit.get_file_info(Path('foo.f90')) \
+            == FileInfo(Path('foo.f90'), 1234)
+        assert test_unit.get_file_info(Path('bar/baz.f90')) \
+            == FileInfo(Path('bar/baz.f90'), 5786)
+
+        test_unit.add_file_info(Path('foo.f90'), 987)
+        assert test_unit.get_file_info(Path('foo.f90')) \
+            == FileInfo(Path('foo.f90'), 987)
+        assert test_unit.get_file_info(Path('bar/baz.f90')) \
+            == FileInfo(Path('bar/baz.f90'), 5786)

--- a/unit-tests/database_test.py
+++ b/unit-tests/database_test.py
@@ -4,14 +4,30 @@
 # which you should have received as part of this distribution
 ##############################################################################
 from pathlib import Path
+import sqlite3
 import pytest  # type: ignore
 
-from fab.database import StateDatabase, FileInfo, WorkingStateException
+from fab.database import SqliteStateDatabase, \
+                         FileInfoDatabase, \
+                         FileInfo, \
+                         WorkingStateException
 
 
-class TestStateDatabase(object):
+class TestSQLiteStateDatabase(object):
+    def test_constructor(self, tmp_path: Path):
+        _ = SqliteStateDatabase(tmp_path)
+
+        db_file = tmp_path / 'state.db'
+        assert db_file.exists()
+
+        # Check we can open the database without exceptions
+        connection = sqlite3.Connection(str(db_file))
+        connection.close()
+
+
+class TestFileInfoDatabase(object):
     def test_file_info(self, tmp_path: Path):
-        test_unit = StateDatabase(tmp_path)
+        test_unit = FileInfoDatabase(SqliteStateDatabase(tmp_path))
 
         with pytest.raises(WorkingStateException):
             test_unit.get_file_info(Path('foo.f90'))

--- a/unit-tests/database_test.py
+++ b/unit-tests/database_test.py
@@ -31,18 +31,24 @@ class TestFileInfoDatabase(object):
 
         with pytest.raises(WorkingStateException):
             test_unit.get_file_info(Path('foo.f90'))
+        assert list(test_unit.get_all_filenames()) == []
 
         test_unit.add_file_info(Path('foo.f90'), 1234)
+        assert list(test_unit.get_all_filenames()) == [Path('foo.f90')]
         assert test_unit.get_file_info(Path('foo.f90')) \
             == FileInfo(Path('foo.f90'), 1234)
 
         test_unit.add_file_info(Path('bar/baz.f90'), 5786)
+        assert list(test_unit.get_all_filenames()) == [Path('bar/baz.f90'),
+                                                       Path('foo.f90')]
         assert test_unit.get_file_info(Path('foo.f90')) \
             == FileInfo(Path('foo.f90'), 1234)
         assert test_unit.get_file_info(Path('bar/baz.f90')) \
             == FileInfo(Path('bar/baz.f90'), 5786)
 
         test_unit.add_file_info(Path('foo.f90'), 987)
+        assert list(test_unit.get_all_filenames()) == [Path('bar/baz.f90'),
+                                                       Path('foo.f90')]
         assert test_unit.get_file_info(Path('foo.f90')) \
             == FileInfo(Path('foo.f90'), 987)
         assert test_unit.get_file_info(Path('bar/baz.f90')) \

--- a/unit-tests/language/fortran_test.py
+++ b/unit-tests/language/fortran_test.py
@@ -10,7 +10,7 @@ from typing import Dict, List, Sequence
 
 import pytest
 
-from fab.database import StateDatabase, WorkingStateException
+from fab.database import SqliteStateDatabase, WorkingStateException
 from fab.language import AnalysisException
 from fab.language.fortran import FortranAnalyser, FortranWorkingState
 
@@ -44,7 +44,7 @@ class TestFortranWorkingSpace:
         Walks a FortranWorkingState object through a sequence of adds and
         removes checking the contents at each stage.
         '''
-        database = StateDatabase(tmp_path)
+        database = SqliteStateDatabase(tmp_path)
         test_unit = FortranWorkingState(database)
 
         # Add a file containing a program unit and an unsatisfied dependency.
@@ -122,7 +122,7 @@ class TestFortranWorkingSpace:
                        expected_dependency)
 
     def test_unit_iterator(self, tmp_path):
-        database = StateDatabase(tmp_path)
+        database = SqliteStateDatabase(tmp_path)
         test_unit = FortranWorkingState(database)
 
         test_unit.add_fortran_program_unit('foo', tmp_path / 'foo.f90')
@@ -175,7 +175,7 @@ class TestFortranAnalyser(object):
                                          'baz': ['teapot_mod'],
                                          'qux': ['wibble_mod', 'wubble_mod']}
 
-        database: StateDatabase = StateDatabase(tmp_path)
+        database: SqliteStateDatabase = SqliteStateDatabase(tmp_path)
         test_unit = FortranAnalyser(database)
         test_unit.analyse(test_file)
         working_state = FortranWorkingState(database)
@@ -236,7 +236,7 @@ class TestFortranAnalyser(object):
                    '''))
         units: List[str] = ['fred', 'barney']
 
-        database: StateDatabase = StateDatabase(tmp_path)
+        database: SqliteStateDatabase = SqliteStateDatabase(tmp_path)
         test_unit = FortranAnalyser(database)
         test_unit.analyse(test_file)
         working_state = FortranWorkingState(database)
@@ -269,7 +269,7 @@ class TestFortranAnalyser(object):
                    end module barney_mod
                    '''))
 
-        database: StateDatabase = StateDatabase(tmp_path)
+        database: SqliteStateDatabase = SqliteStateDatabase(tmp_path)
         test_unit = FortranAnalyser(database)
         test_unit.analyse(first_file)
         test_unit.analyse(second_file)
@@ -304,7 +304,7 @@ class TestFortranAnalyser(object):
                    end module test_mod
                    '''))
 
-        database: StateDatabase = StateDatabase(tmp_path)
+        database: SqliteStateDatabase = SqliteStateDatabase(tmp_path)
         test_unit = FortranAnalyser(database)
         with pytest.raises(AnalysisException):
             test_unit.analyse(test_file)

--- a/unit-tests/language/fortran_test.py
+++ b/unit-tests/language/fortran_test.py
@@ -8,11 +8,12 @@ from pathlib import Path
 from textwrap import dedent
 from typing import Dict, List, Sequence
 
-import pytest
+import pytest  # type: ignore
 
 from fab.database import SqliteStateDatabase, WorkingStateException
 from fab.language import AnalysisException
 from fab.language.fortran import FortranAnalyser, FortranWorkingState
+from fab.reader import FileTextReader
 
 
 class TestFortranWorkingSpace:
@@ -21,20 +22,22 @@ class TestFortranWorkingSpace:
                   expected_unit: Dict[str, Sequence[Path]],
                   expected_filename: Dict[Path, Sequence[str]],
                   expected_dependency: Dict[str, Sequence[str]]):
-        for unit, filename in expected_unit.items():
+        for unit, unit_filename in expected_unit.items():
             if unit.startswith('!'):
                 with pytest.raises(WorkingStateException):
                     _ = test_unit.filenames_from_program_unit(unit[1:])
             else:
-                assert test_unit.filenames_from_program_unit(unit) == filename
+                assert test_unit.filenames_from_program_unit(unit) \
+                    == unit_filename
 
-        for filename, unit in expected_filename.items():
+        for filename, filename_unit in expected_filename.items():
             if filename.suffix == '.not':
                 with pytest.raises(WorkingStateException):
                     actual_filename: Path = filename.with_suffix('')
                     _ = test_unit.program_units_from_file(actual_filename)
             else:
-                assert test_unit.program_units_from_file(filename) == unit
+                assert test_unit.program_units_from_file(filename) \
+                    == filename_unit
 
         for unit, prerequisites in expected_dependency.items():
             assert test_unit.depends_on(unit) == prerequisites
@@ -177,7 +180,7 @@ class TestFortranAnalyser(object):
 
         database: SqliteStateDatabase = SqliteStateDatabase(tmp_path)
         test_unit = FortranAnalyser(database)
-        test_unit.analyse(test_file)
+        test_unit.analyse(FileTextReader(test_file))
         working_state = FortranWorkingState(database)
         assert working_state.program_units_from_file(test_file) == units
         for unit in units:
@@ -238,7 +241,7 @@ class TestFortranAnalyser(object):
 
         database: SqliteStateDatabase = SqliteStateDatabase(tmp_path)
         test_unit = FortranAnalyser(database)
-        test_unit.analyse(test_file)
+        test_unit.analyse(FileTextReader(test_file))
         working_state = FortranWorkingState(database)
         assert working_state.program_units_from_file(test_file) == units
         for unit in units:
@@ -271,8 +274,8 @@ class TestFortranAnalyser(object):
 
         database: SqliteStateDatabase = SqliteStateDatabase(tmp_path)
         test_unit = FortranAnalyser(database)
-        test_unit.analyse(first_file)
-        test_unit.analyse(second_file)
+        test_unit.analyse(FileTextReader(first_file))
+        test_unit.analyse(FileTextReader(second_file))
 
         fdb = FortranWorkingState(database)
         assert list(fdb.iterate_program_units()) \
@@ -282,7 +285,7 @@ class TestFortranAnalyser(object):
 
         # Repeat the scan of second_file, there should be no change.
         #
-        test_unit.analyse(second_file)
+        test_unit.analyse(FileTextReader(second_file))
 
         fdb = FortranWorkingState(database)
         assert list(fdb.iterate_program_units()) \
@@ -307,4 +310,4 @@ class TestFortranAnalyser(object):
         database: SqliteStateDatabase = SqliteStateDatabase(tmp_path)
         test_unit = FortranAnalyser(database)
         with pytest.raises(AnalysisException):
-            test_unit.analyse(test_file)
+            test_unit.analyse(FileTextReader(test_file))

--- a/unit-tests/reader_test.py
+++ b/unit-tests/reader_test.py
@@ -1,0 +1,70 @@
+##############################################################################
+# (c) Crown copyright Met Office. All rights reserved.
+# For further details please refer to the file COPYRIGHT
+# which you should have received as part of this distribution
+##############################################################################
+from pathlib import Path
+from textwrap import dedent
+
+from pytest import fail  # type: ignore
+
+from fab.reader import FileTextReader, StringTextReader, TextReaderAdler32
+
+
+class TestFileTextReader:
+    def test_constructor(self, tmp_path: Path):
+        test_file = tmp_path / 'teapot/cheese.boo'
+        test_file.parent.mkdir()
+        test_file.write_text('')
+        test_unit = FileTextReader(test_file)
+        assert test_unit.get_filename() == test_file
+
+    def test_reading(self, tmp_path: Path):
+        test_file = tmp_path / 'beef.food'
+        test_file.write_text('This is my test file\nIt has two lines')
+
+        test_unit = FileTextReader(test_file)
+        content = [line for line in test_unit.line_by_line()]
+        assert content == ['This is my test file\n',
+                           'It has two lines']
+
+        # Call again on a now read file...
+        for _ in test_unit.line_by_line():
+            fail(' No lines should be generated from a read file')
+
+
+class TestStringTextReader:
+    def test_constructor(self):
+        string = dedent('''
+            I am in the infantry
+            Battlemechs can stand on me.
+            ''')
+        test_unit = StringTextReader(string)
+        assert isinstance(test_unit.get_filename(), str)
+        assert test_unit.get_filename().startswith('[string:')
+
+    def test_reading(self, tmp_path: Path):
+        test_file = tmp_path / 'beef.food'
+        test_file.write_text('This is my test file\nIt has two lines')
+
+        test_unit = FileTextReader(test_file)
+        content = [line for line in test_unit.line_by_line()]
+        assert content == ['This is my test file\n',
+                           'It has two lines']
+
+        # Call again on a now read file...
+        for _ in test_unit.line_by_line():
+            fail(' No lines should be generated from a read file')
+
+
+class TestTextReaderAdler32:
+    def test_all(self):
+        source = StringTextReader('Bibble\nBobble babble\n')
+        test_unit = TextReaderAdler32(source)
+        content = [line for line in test_unit.line_by_line()]
+        assert content == ['Bibble\n', 'Bobble babble\n']
+        assert test_unit.get_hash() == 1329530643
+
+        # Call again on a now read file...
+        for _ in test_unit.line_by_line():
+            fail(' No lines should be generated from a read file')

--- a/unit-tests/reader_test.py
+++ b/unit-tests/reader_test.py
@@ -17,7 +17,7 @@ class TestFileTextReader:
         test_file.parent.mkdir()
         test_file.write_text('')
         test_unit = FileTextReader(test_file)
-        assert test_unit.get_filename() == test_file
+        assert test_unit.filename == test_file
 
     def test_reading(self, tmp_path: Path):
         test_file = tmp_path / 'beef.food'
@@ -40,8 +40,8 @@ class TestStringTextReader:
             Battlemechs can stand on me.
             ''')
         test_unit = StringTextReader(string)
-        assert isinstance(test_unit.get_filename(), str)
-        assert test_unit.get_filename().startswith('[string:')
+        assert isinstance(test_unit.filename, str)
+        assert test_unit.filename.startswith('[string:')
 
     def test_reading(self, tmp_path: Path):
         test_file = tmp_path / 'beef.food'
@@ -63,7 +63,7 @@ class TestTextReaderAdler32:
         test_unit = TextReaderAdler32(source)
         content = [line for line in test_unit.line_by_line()]
         assert content == ['Bibble\n', 'Bobble babble\n']
-        assert test_unit.get_hash() == 1329530643
+        assert test_unit.hash == 1329530643
 
         # Call again on a now read file...
         for _ in test_unit.line_by_line():

--- a/unit-tests/source_tree_test.py
+++ b/unit-tests/source_tree_test.py
@@ -6,7 +6,7 @@
 from pathlib import Path
 from typing import List
 
-from fab.database import StateDatabase
+from fab.database import SqliteStateDatabase
 from fab.language import Analyser
 from fab.source_tree import ExtensionVisitor, TreeDescent, TreeVisitor
 
@@ -37,7 +37,7 @@ def test_descent(tmp_path: Path):
 
 
 class DummyAnalyser(Analyser):
-    def __init__(self, db: StateDatabase):
+    def __init__(self, db: SqliteStateDatabase):
         super().__init__(db)
         self.seen: List[Path] = []
 
@@ -46,7 +46,7 @@ class DummyAnalyser(Analyser):
 
 
 def test_extension_visitor(tmp_path: Path):
-    db = StateDatabase(tmp_path)
+    db = SqliteStateDatabase(tmp_path)
     emap = {'.foo': DummyAnalyser(db),
             '.bar': DummyAnalyser(db)}
     test_unit = ExtensionVisitor(emap)

--- a/unit-tests/source_tree_test.py
+++ b/unit-tests/source_tree_test.py
@@ -38,7 +38,8 @@ def test_descent(tmp_path: Path):
 
 
 class DummyReader(TextReader):
-    def get_filename(self) -> Union[Path, str]:
+    @property
+    def filename(self) -> Union[Path, str]:
         return Path('/dummy')
 
     def line_by_line(self) -> Iterator[str]:
@@ -69,25 +70,25 @@ def test_extension_visitor(tmp_path: Path):
     test_unit = ExtensionVisitor(emap)
 
     test_unit.visit(foo_file)
-    assert emap['.foo'].last_seen.get_filename() == tmp_path / 'file.foo'
+    assert emap['.foo'].last_seen.filename == tmp_path / 'file.foo'
     assert file_info.get_file_info(foo_file) \
         == FileInfo(tmp_path / 'file.foo', 345244617)
     assert isinstance(emap['.bar'].last_seen, DummyReader)
 
     test_unit.visit(bar_file)
-    assert emap['.foo'].last_seen.get_filename() == tmp_path / 'file.foo'
+    assert emap['.foo'].last_seen.filename == tmp_path / 'file.foo'
     assert file_info.get_file_info(foo_file) \
         == FileInfo(tmp_path / 'file.foo', 345244617)
-    assert emap['.bar'].last_seen.get_filename() \
+    assert emap['.bar'].last_seen.filename \
         == tmp_path / 'dir' / 'file.bar'
     assert file_info.get_file_info(bar_file) \
         == FileInfo(tmp_path / 'dir' / 'file.bar', 2333477459)
 
     test_unit.visit(tmp_path / 'file.baz')
-    assert emap['.foo'].last_seen.get_filename() == tmp_path / 'file.foo'
+    assert emap['.foo'].last_seen.filename == tmp_path / 'file.foo'
     assert file_info.get_file_info(foo_file) \
         == FileInfo(tmp_path / 'file.foo', 345244617)
-    assert emap['.bar'].last_seen.get_filename() \
+    assert emap['.bar'].last_seen.filename \
         == tmp_path / 'dir' / 'file.bar'
     assert file_info.get_file_info(bar_file) \
         == FileInfo(tmp_path / 'dir' / 'file.bar', 2333477459)

--- a/unit-tests/source_tree_test.py
+++ b/unit-tests/source_tree_test.py
@@ -4,10 +4,11 @@
 # which you should have received as part of this distribution
 ##############################################################################
 from pathlib import Path
-from typing import List
+from typing import Iterator, Union
 
-from fab.database import SqliteStateDatabase
+from fab.database import SqliteStateDatabase, FileInfoDatabase, FileInfo
 from fab.language import Analyser
+from fab.reader import TextReader
 from fab.source_tree import ExtensionVisitor, TreeDescent, TreeVisitor
 
 
@@ -36,28 +37,57 @@ def test_descent(tmp_path: Path):
                                tree_root / 'beta' / 'delta']
 
 
+class DummyReader(TextReader):
+    def get_filename(self) -> Union[Path, str]:
+        return Path('/dummy')
+
+    def line_by_line(self) -> Iterator[str]:
+        yield 'dummy'
+
+
 class DummyAnalyser(Analyser):
     def __init__(self, db: SqliteStateDatabase):
         super().__init__(db)
-        self.seen: List[Path] = []
+        self.last_seen: TextReader = DummyReader()
 
-    def analyse(self, filename: Path):
-        self.seen.append(filename)
+    def analyse(self, file: TextReader):
+        self.last_seen = file
 
 
 def test_extension_visitor(tmp_path: Path):
+    foo_file = tmp_path / 'file.foo'
+    foo_file.write_text('First file')
+    (tmp_path / 'dir').mkdir()
+    bar_file = tmp_path / 'dir' / 'file.bar'
+    bar_file.write_text('Second file in subdirectory')
+
     db = SqliteStateDatabase(tmp_path)
+    file_info = FileInfoDatabase(db)
+
     emap = {'.foo': DummyAnalyser(db),
             '.bar': DummyAnalyser(db)}
     test_unit = ExtensionVisitor(emap)
-    test_unit.visit(tmp_path / 'file.foo')
-    assert emap['.foo'].seen == [tmp_path / 'file.foo']
-    assert emap['.bar'].seen == []
 
-    test_unit.visit(tmp_path / 'dir' / 'file.bar')
-    assert emap['.foo'].seen == [tmp_path / 'file.foo']
-    assert emap['.bar'].seen == [tmp_path / 'dir' / 'file.bar']
+    test_unit.visit(foo_file)
+    assert emap['.foo'].last_seen.get_filename() == tmp_path / 'file.foo'
+    assert file_info.get_file_info(foo_file) \
+        == FileInfo(tmp_path / 'file.foo', 345244617)
+    assert isinstance(emap['.bar'].last_seen, DummyReader)
+
+    test_unit.visit(bar_file)
+    assert emap['.foo'].last_seen.get_filename() == tmp_path / 'file.foo'
+    assert file_info.get_file_info(foo_file) \
+        == FileInfo(tmp_path / 'file.foo', 345244617)
+    assert emap['.bar'].last_seen.get_filename() \
+        == tmp_path / 'dir' / 'file.bar'
+    assert file_info.get_file_info(bar_file) \
+        == FileInfo(tmp_path / 'dir' / 'file.bar', 2333477459)
 
     test_unit.visit(tmp_path / 'file.baz')
-    assert emap['.foo'].seen == [tmp_path / 'file.foo']
-    assert emap['.bar'].seen == [tmp_path / 'dir' / 'file.bar']
+    assert emap['.foo'].last_seen.get_filename() == tmp_path / 'file.foo'
+    assert file_info.get_file_info(foo_file) \
+        == FileInfo(tmp_path / 'file.foo', 345244617)
+    assert emap['.bar'].last_seen.get_filename() \
+        == tmp_path / 'dir' / 'file.bar'
+    assert file_info.get_file_info(bar_file) \
+        == FileInfo(tmp_path / 'dir' / 'file.bar', 2333477459)


### PR DESCRIPTION
This work relates to ticket #26.
In order to support flexible processing of the incoming files a `TextReader` class has been introduced. This is part of an implementation of the decorator pattern which allows two sources (file and string) to then be onion wrapped in as many different modifiers as you like. Each modifier sees the output of all previous modifiers in the stack.
The Hash calculation is implemented as such a modifier so it is important that it not appear after a previous modifier has changed the content of the file. The hashing algorithm used is "Adler32". This gives performance comparable with CRC32 but is faster to compute.
The Fortran source normalisation stage is re-implemented as a decoration of `TextReader`.
The state database is also reimplemented using the decorator pattern. It is not expected that this object structure will get particularly deep although it could. The goal here is to have a single underlying database with as many personas as needed on top of it. So "file information" is on persona which knows about things like file hashes. Meanwhile "fortran" is a persona which knows about program units and dependencies.
The database implementation has also been enhanced to hide more of the details of the underlying database from users. It still requires them to provide SQL queries but it should no longer require them to import the `sqlite3` module.