### PR TITLE
Improve unit test coverage, take 2

### DIFF
--- a/source/fab/application.py
+++ b/source/fab/application.py
@@ -107,7 +107,7 @@ class Fab(object):
         flags = self._command_flags_map.get(FortranLinker, [])
         link_command = FortranLinker(self._workspace, flags, executable)
 
-        processed_units = []
+        processed_units: List[str] = []
 
         while unit_to_process:
             # Pop pending items from start of the list

--- a/source/fab/database.py
+++ b/source/fab/database.py
@@ -22,8 +22,10 @@ class FileInfo(object):
         self.adler32 = adler32
 
     def __eq__(self, other):
+        if not isinstance(other, FileInfo):
+            raise ValueError('Cannot compare FileInfo with none FileInfo')
         return (str(other.filename) == str(self.filename)) \
-               and (other.adler32 == self.adler32)
+            and (other.adler32 == self.adler32)
 
 
 class DatabaseRows(Iterator[Dict[str, str]]):

--- a/source/fab/language/__init__.py
+++ b/source/fab/language/__init__.py
@@ -9,7 +9,7 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import List
 
-from fab.database import SqliteStateDatabase
+from fab.database import StateDatabase
 from fab.reader import TextReader
 
 
@@ -33,8 +33,8 @@ class Task(ABC):
         raise NotImplementedError('Abstract methods must be implemented')
 
 
-class Analyser(Task):
-    def __init__(self, reader: TextReader, database: SqliteStateDatabase):
+class Analyser(Task, ABC):
+    def __init__(self, reader: TextReader, database: StateDatabase):
         self._database = database
         self._reader = reader
 
@@ -44,7 +44,10 @@ class Analyser(Task):
 
     @property
     def prerequisites(self) -> List[Path]:
-        return [Path(self._reader.filename)]
+        if isinstance(self._reader.filename, Path):
+            return [self._reader.filename]
+        else:
+            return []
 
     @property
     def products(self) -> List[Path]:
@@ -52,11 +55,14 @@ class Analyser(Task):
 
 
 class Command(ABC):
-    stdout = False
-
-    def __init__(self, workspace: Path, flags: List[str]):
+    def __init__(self, workspace: Path, flags: List[str], stdout=False):
         self._workspace = workspace
         self._flags = flags
+        self._output_is_stdout = stdout
+
+    @property
+    def stdout(self) -> bool:
+        return self._output_is_stdout
 
     @property
     @abstractmethod
@@ -74,7 +80,7 @@ class Command(ABC):
         raise NotImplementedError('Abstract methods must be implemented')
 
 
-class SingleFileCommand(Command):
+class SingleFileCommand(Command, ABC):
     def __init__(self, filename: Path, workspace: Path, flags: List[str]):
         super().__init__(workspace, flags)
         self._filename = filename
@@ -89,10 +95,14 @@ class CommandTask(Task):
         self._command = command
 
     def run(self):
-        process = subprocess.run(self._command.as_list, check=True)
         if self._command.stdout:
-            with open(self._command.output_filename, 'wb') as out_file:
+            process = subprocess.run(self._command.as_list,
+                                     check=True,
+                                     stdout=subprocess.PIPE)
+            with self._command.output[0].open('wb') as out_file:
                 out_file.write(process.stdout)
+        else:
+            _ = subprocess.run(self._command.as_list, check=True)
 
     @property
     def prerequisites(self) -> List[Path]:

--- a/source/fab/language/fortran.py
+++ b/source/fab/language/fortran.py
@@ -201,7 +201,7 @@ class FortranWorkingState(DatabaseDecorator):
         return units
 
 
-class _FortranNormaliser(TextReaderDecorator):
+class FortranNormaliser(TextReaderDecorator):
     def __init__(self, source: TextReader):
         super().__init__(source)
         self._line_buffer = ''
@@ -229,7 +229,7 @@ class _FortranNormaliser(TextReaderDecorator):
             # the lines together
             self._line_buffer += line
             if '&' in self._line_buffer:
-                self._line_buffer = re.sub(r'&\s*\n', '', self._line_buffer)
+                self._line_buffer = re.sub(r'&\s*$', '', self._line_buffer)
                 continue
 
             # Before output, minimise whitespace but add a space on the end
@@ -301,7 +301,7 @@ class FortranAnalyser(Analyser):
 
         self._state.remove_fortran_file(self._reader.filename)
 
-        normalised_source = _FortranNormaliser(self._reader)
+        normalised_source = FortranNormaliser(self._reader)
         scope: List[Tuple[str, str]] = []
         for line in normalised_source.line_by_line():
             logger.debug(scope)
@@ -462,6 +462,9 @@ class FortranLinker(Command):
 
     @property
     def as_list(self) -> List[str]:
+        if len(self._filenames) == 0:
+            message = "Tried to generate a link without object files"
+            raise TaskException(message)
         base_command = ['gfortran', '-o', str(self._output_filename)]
         objects = [str(filename) for filename in self._filenames]
         return base_command + self._flags + objects

--- a/unit-tests/application_test.py
+++ b/unit-tests/application_test.py
@@ -1,0 +1,10 @@
+##############################################################################
+# (c) Crown copyright Met Office. All rights reserved.
+# For further details please refer to the file COPYRIGHT
+# which you should have received as part of this distribution
+##############################################################################
+# Each class in application.py embodies an entire utility. In effect the
+# "unit" is the entire tool. As such any unit testing would effectively be
+# system testing.
+#
+# TODO: We may wish to consider how much stuff is in these top level objects.

--- a/unit-tests/database_test.py
+++ b/unit-tests/database_test.py
@@ -7,10 +7,75 @@ from pathlib import Path
 import sqlite3
 import pytest  # type: ignore
 
-from fab.database import SqliteStateDatabase, \
-                         FileInfoDatabase, \
-                         FileInfo, \
-                         WorkingStateException
+from fab.database import (DatabaseRows,
+                          FileInfo,
+                          FileInfoDatabase,
+                          SqliteStateDatabase,
+                          WorkingStateException)
+
+
+class TestFileInfo(object):
+    def test_constructor(self):
+        test_unit = FileInfo(Path('stuff/nonsense'), 1234)
+        assert test_unit.filename == Path('stuff/nonsense')
+        assert test_unit.adler32 == 1234
+
+    def equality_cases(self, request):
+        yield request.param
+
+    def test_equality(self):
+        first = FileInfo(Path('stuff/nonsense'), 5678)
+        with pytest.raises(ValueError):
+            _ = first == 'Not a FileInfo'
+
+        second = FileInfo(Path('stuff/nonsense'), 5678)
+        assert first == second
+        assert second == first
+
+        second = FileInfo(Path('bobbins'), 5678)
+        assert first != second
+
+        second = FileInfo(Path('stuff/nonsense'), 1234)
+        assert first != second
+
+        second = FileInfo(Path('bobbins'), 1234)
+        assert first != second
+
+
+class TestDatabaseRows(object):
+    def test_iteration(self):
+        test_unit = DatabaseRows(None)
+        with pytest.raises(StopIteration):
+            next(test_unit)
+
+        connection = sqlite3.connect(':memory:')
+        connection.execute('''create table test_table
+                              (first integer, second character(10))''')
+        connection.commit()
+
+        cursor = connection.cursor()
+        cursor.execute('select * from test_table')
+        test_unit = DatabaseRows(cursor)
+        assert list(iter(test_unit)) == []
+
+        connection.execute('''insert into test_table (first, second)
+                              values (13, "spooky")''')
+        connection.commit()
+
+        cursor = connection.cursor()
+        cursor.execute('select * from test_table')
+        test_unit = DatabaseRows(cursor)
+        assert list(iter(test_unit)) == [(13, 'spooky')]
+
+        connection.execute('''insert into test_table (first, second)
+                              values (666, "devilish")''')
+        connection.commit()
+
+        cursor = connection.cursor()
+        cursor.execute('select * from test_table')
+        test_unit = DatabaseRows(cursor)
+        assert list(iter(test_unit)) == [(13, 'spooky'),
+                                         (666, 'devilish')]
 
 
 class TestSQLiteStateDatabase(object):
@@ -18,6 +83,15 @@ class TestSQLiteStateDatabase(object):
         _ = SqliteStateDatabase(tmp_path)
 
         db_file = tmp_path / 'state.db'
+        assert db_file.exists()
+
+        # Check we can open the database without exceptions
+        connection = sqlite3.Connection(str(db_file))
+        connection.close()
+
+        _ = SqliteStateDatabase(tmp_path / 'extra')
+
+        db_file = tmp_path / 'extra' / 'state.db'
         assert db_file.exists()
 
         # Check we can open the database without exceptions

--- a/unit-tests/entry_test.py
+++ b/unit-tests/entry_test.py
@@ -1,0 +1,10 @@
+##############################################################################
+# (c) Crown copyright Met Office. All rights reserved.
+# For further details please refer to the file COPYRIGHT
+# which you should have received as part of this distribution
+##############################################################################
+# The entry.py module holds the application entry points. By definition
+# testing on of these is effectively testing the entire application along with
+# command line handling and all manner of other complications.
+#
+# We defer such system testing to a set of specific system tests.

--- a/unit-tests/language/__init__test.py
+++ b/unit-tests/language/__init__test.py
@@ -1,0 +1,116 @@
+# (c) Crown copyright Met Office. All rights reserved.
+# For further details please refer to the file COPYRIGHT
+# which you should have received as part of this distribution
+from pathlib import Path
+from typing import Union, Sequence, Dict, List
+
+from fab.database import DatabaseRows, StateDatabase
+from fab.language import Analyser, Command, CommandTask, SingleFileCommand
+from fab.reader import FileTextReader, StringTextReader
+
+
+class DummyDatabase(StateDatabase):
+    def execute(self,
+                query: Union[Sequence[str], str],
+                inserts: Dict[str, str]) -> DatabaseRows:
+        pass
+
+
+class AnalyserHarness(Analyser):
+    def run(self) -> None:
+        pass
+
+
+class TestAnalyser(object):
+    def test_constructor_with_file(self, tmp_path: Path):
+        (tmp_path / 'foo').write_text('Hello')
+        db = DummyDatabase()
+        test_unit = AnalyserHarness(FileTextReader(tmp_path / 'foo'), db)
+        assert test_unit.database == db
+        assert test_unit.prerequisites == [tmp_path / 'foo']
+        assert test_unit.products == []
+
+    def test_constructor_with_string(self):
+        db = DummyDatabase()
+        test_unit = AnalyserHarness(StringTextReader('Hello'), db)
+        assert test_unit.database == db
+        assert test_unit.prerequisites == []
+        assert test_unit.products == []
+
+
+class SingleFileCommandHarness(SingleFileCommand):
+    @property
+    def as_list(self) -> List[str]:
+        return []
+
+    @property
+    def output(self) -> List[Path]:
+        return []
+
+
+class TestSingleFileCommand(object):
+    def test_constructor(self):
+        test_unit = SingleFileCommandHarness(Path('this/that'),
+                                             Path('thing/otherthing'),
+                                             ['beef', 'cheese'])
+        assert test_unit.input == [Path('this/that')]
+
+
+class DummyCommand(Command):
+    def __init__(self, workspace: Path, flags: List[str], stdout: bool):
+        super().__init__(workspace, flags, stdout)
+        self._output = workspace / 'run.touch'
+
+    @property
+    def as_list(self) -> List[str]:
+        return ['touch', str(self._output)]
+
+    @property
+    def output(self) -> List[Path]:
+        return [Path('output')]
+
+    @property
+    def input(self) -> List[Path]:
+        return [Path('input')]
+
+
+class DummyTerminalCommand(Command):
+    def __init__(self, workspace: Path, flags: List[str], stdout: bool):
+        super().__init__(workspace, flags, stdout)
+        self._output = workspace / 'run.out'
+
+    @property
+    def as_list(self) -> List[str]:
+        return ['echo', 'run']
+
+    @property
+    def output(self) -> List[Path]:
+        return [self._output]
+
+    @property
+    def input(self) -> List[Path]:
+        return [Path('input')]
+
+
+class TestCommandTask(object):
+    def test_constructor(self):
+        test_unit = CommandTask(DummyCommand(Path('workspace'),
+                                             ['wargle', 'bargle'],
+                                             False))
+        assert test_unit.prerequisites == [Path('input')]
+        assert test_unit.products == [Path('output')]
+
+    def test_run_file_output(self, tmp_path: Path):
+        test_unit = CommandTask(DummyCommand(tmp_path,
+                                             ['wargle', 'bargle'],
+                                             False))
+        test_unit.run()
+        assert (tmp_path / 'run.touch').exists()
+
+    def test_run_terminal_output(self, tmp_path: Path):
+        test_unit = CommandTask(DummyTerminalCommand(tmp_path,
+                                                     ['wargle', 'bargle'],
+                                                     True))
+        test_unit.run()
+        assert (tmp_path / 'run.out').exists()
+        assert (tmp_path / 'run.out').read_text() == 'run\n'

--- a/unit-tests/language/fortran_test.py
+++ b/unit-tests/language/fortran_test.py
@@ -6,17 +6,19 @@
 import logging
 from pathlib import Path
 from textwrap import dedent
-from typing import Dict, List, Sequence
+from typing import Dict, Iterator, List, Union, Sequence
 
 import pytest  # type: ignore
 
 from fab.database import SqliteStateDatabase, WorkingStateException
 from fab.language import TaskException, CommandTask
-from fab.language.fortran import (
-    FortranAnalyser,
-    FortranWorkingState,
-    FortranPreProcessor)
-from fab.reader import FileTextReader
+from fab.language.fortran import (FortranAnalyser,
+                                  FortranCompiler,
+                                  FortranLinker,
+                                  FortranNormaliser,
+                                  FortranPreProcessor,
+                                  FortranWorkingState)
+from fab.reader import FileTextReader, StringTextReader, TextReader
 
 
 class TestFortranWorkingSpace:
@@ -143,6 +145,30 @@ class TestFortranWorkingSpace:
         assert list(test_unit.iterate_program_units()) == expected
 
 
+class DummyReader(TextReader):
+    @property
+    def filename(self) -> Union[Path, str]:
+        return '<dummy>'
+
+    def line_by_line(self) -> Iterator[str]:
+        yield '! This comment should be removed and the line with it'
+        yield "write(6, '(A)') 'Look! The end of this line will be removed'"
+        yield '     ! Another line to be removed despite leading spaces'
+        yield '  call the_thing( first,  &'
+        yield '                  second, &'
+        yield '                  third )'
+
+
+class TestFortranNormaliser(object):
+    def test_iteration(self):
+        test_unit = FortranNormaliser(DummyReader())
+        result = []
+        for line in test_unit.line_by_line():
+            result.append(line)
+        assert result == ["write(6, '(A)') 'Look",
+                          ' call the_thing( first, second, third )']
+
+
 class TestFortranAnalyser(object):
     def test_analyser_program_units(self, caplog, tmp_path):
         '''
@@ -155,21 +181,29 @@ class TestFortranAnalyser(object):
         test_file.write_text(
             dedent('''
                    program foo
+                     use iso_fortran_env, only : output
+                     use, intrinsic :: ios_c_binding
                      use beef_mod
                      implicit none
                    end program foo
 
                    module bar
+                     use iso_fortran_env, only : output
+                     use, intrinsic :: ios_c_binding
                      use cheese_mod, only : bits_n_bobs
                      implicit none
                    end module bar
 
                    function baz(first, second)
+                     use iso_fortran_env, only : output
+                     use, intrinsic :: ios_c_binding
                      use teapot_mod
                      implicit none
                    end function baz
 
                    subroutine qux()
+                     use iso_fortran_env, only : output
+                     use, intrinsic :: ios_c_binding
                      use wibble_mod
                      use wubble_mod, only: stuff_n_nonsense
                      implicit none
@@ -317,6 +351,39 @@ class TestFortranAnalyser(object):
         with pytest.raises(TaskException):
             test_unit.run()
 
+    def test_mismatched_block_end(self, tmp_path: Path):
+        """
+        Ensure that the analyser handles mismatched block ends correctly.
+        """
+        source = """
+        module wibble_mod
+        contains
+          type :: thing_type
+          end if
+        end module wibble_mod
+        """
+        database = SqliteStateDatabase(tmp_path)
+        test_unit = FortranAnalyser(StringTextReader(source),
+                                    database)
+        with pytest.raises(TaskException):
+            test_unit.run()
+
+    def test_mismatched_end_name(self, tmp_path: Path):
+        """
+        Ensure that the analyser handles mismatched block end names correctly.
+        """
+        source = """
+        module wibble_mod
+          type :: thing_type
+          end type blasted_type
+        end module wibble_mod
+        """
+        database = SqliteStateDatabase(tmp_path)
+        test_unit = FortranAnalyser(StringTextReader(source),
+                                    database)
+        with pytest.raises(TaskException):
+            test_unit.run()
+
 
 class TestFortranPreProcessor(object):
     def test_preprocssor_output(self, caplog, tmp_path):
@@ -356,7 +423,7 @@ class TestFortranPreProcessor(object):
         test_unit.run()
 
         assert preprocessor.output[0].exists
-        with open(preprocessor.output[0], 'r') as outfile:
+        with preprocessor.output[0].open('r') as outfile:
             outfile_content = outfile.read().strip()
 
         assert outfile_content == dedent('''\
@@ -376,7 +443,7 @@ class TestFortranPreProcessor(object):
         test_unit.run()
 
         assert preprocessor.output[0].exists
-        with open(preprocessor.output[0], 'r') as outfile:
+        with preprocessor.output[0].open('r') as outfile:
             outfile_content = outfile.read().strip()
 
         assert outfile_content == dedent('''\
@@ -386,3 +453,46 @@ class TestFortranPreProcessor(object):
                    FUNCTION included_when_test_macro_not_set()
                    IMPLICIT NONE
                    END FUNCTION included_when_test_macro_not_set''')
+
+
+class TestFortranCompiler(object):
+    def test_constructor(self):
+        test_unit = FortranCompiler(Path('input.f90'),
+                                    Path('workspace'),
+                                    ['flag1', 'flag2'],
+                                    [Path('prereq1.mod'),
+                                     Path('prereq2.mod')])
+        assert test_unit.input == [Path('prereq1.mod'),
+                                   Path('prereq2.mod'),
+                                   Path('input.f90')]
+        assert test_unit.output == [Path('workspace/input.o')]
+        assert test_unit.as_list == ['gfortran', '-c', '-Jworkspace',
+                                     'flag1', 'flag2', 'input.f90',
+                                     '-o', 'workspace/input.o']
+
+
+class TestFortranLinker(object):
+    def test_constructor(self):
+        test_unit = FortranLinker(Path('workspace'),
+                                  ['flag3', 'flag4'],
+                                  Path('bin/output'))
+        test_unit.add_object(Path('an.o'))
+        assert test_unit.input == [Path('an.o')]
+        assert test_unit.output == [Path('bin/output')]
+        assert test_unit.as_list == ['gfortran', '-o', 'bin/output',
+                                     'flag3', 'flag4', 'an.o']
+
+    def test_add_object(self):
+        test_unit = FortranLinker(Path('deepspace'),
+                                  [],
+                                  Path('bin/dusty'))
+        with pytest.raises(TaskException):
+            _ = test_unit.as_list
+
+        test_unit.add_object(Path('foo.o'))
+        assert test_unit.as_list == ['gfortran', '-o', 'bin/dusty',
+                                     'foo.o']
+
+        test_unit.add_object(Path('bar.o'))
+        assert test_unit.as_list == ['gfortran', '-o', 'bin/dusty',
+                                     'foo.o', 'bar.o']

--- a/unit-tests/source_tree_test.py
+++ b/unit-tests/source_tree_test.py
@@ -4,148 +4,157 @@
 # which you should have received as part of this distribution
 ##############################################################################
 from pathlib import Path
-from typing import Iterator, Union, List, Mapping, Dict, Type
+import pytest
+from typing import Union, List, Dict, Type
 
-from fab.database import SqliteStateDatabase, FileInfoDatabase, FileInfo
+from fab.database import SqliteStateDatabase
 from fab.language import Analyser, Command, SingleFileCommand, Task
-from fab.reader import TextReader
 from fab.source_tree import ExtensionVisitor, TreeDescent, TreeVisitor
 from fab.queue import QueueManager
 
 
-class DummyVisitor(TreeVisitor):
-    def __init__(self):
-        self.visited = []
+class TestExtensionVisitor(object):
+    def test_analyser(self, tmp_path: Path):
+        (tmp_path / 'test.foo').write_text("First file")
+        (tmp_path / 'directory').mkdir()
+        (tmp_path / 'directory' / 'file.foo').write_text("Second file in directory")
 
-    def visit(self, candidate: Path) -> List[Path]:
-        self.visited.append(candidate)
-        return []
+        tracker: List[Path] = []
 
+        class DummyTask(Analyser):
+            def run(self):
+                tracker.append(self._reader.filename)
 
-def test_descent(tmp_path: Path):
-    tree_root = tmp_path / 'alpha'
-    tree_root.mkdir()
-    (tree_root / 'beta').mkdir()
-    (tree_root / 'gamma').write_text('File in root')
-    (tree_root / 'beta' / 'delta').write_text('File in beta')
-    (tree_root / 'beta' / 'epsilon').write_text('Another file in beta')
-
-    test_unit = TreeDescent(tree_root)
-    visitor = DummyVisitor()
-    test_unit.descend(visitor)
-
-    assert visitor.visited == [tree_root / 'gamma',
-                               tree_root / 'beta' / 'epsilon',
-                               tree_root / 'beta' / 'delta']
-
-
-class DummyReader(TextReader):
-    @property
-    def filename(self) -> Union[Path, str]:
-        return Path('/dummy')
-
-    def line_by_line(self) -> Iterator[str]:
-        yield 'dummy'
-
-
-tracker: Mapping[str, List[Path]] = {
-    'analyser': [],
-    'command': [],
-}
-
-
-def setup_function():
-    tracker['analyser'] = []
-    tracker['command'] = []
-
-
-class DummyAnalyser(Analyser):
-    def run(self):
-        tracker['analyser'].append(self._reader.filename)
-
-
-class DummyCommand(SingleFileCommand):
-    @property
-    def as_list(self) -> List[str]:
-        tracker['command'].append(self._filename)
-        return ['cp', str(self._filename), str(self.output[0])]
-
-    @property
-    def output(self) -> List[Path]:
-        return [self._filename.with_suffix('.baz')]
-
-
-def test_extension_visitor(tmp_path: Path):
-    foo_file = tmp_path / 'file.foo'
-    foo_file.write_text('First file')
-    (tmp_path / 'dir').mkdir()
-    bar_file = tmp_path / 'dir' / 'file.bar'
-    bar_file.write_text('Second file in subdirectory')
-    baz_file = tmp_path / 'file.baz'  # Doesn't exist
-
-    db = SqliteStateDatabase(tmp_path)
-    file_info = FileInfoDatabase(db)
-
-    emap: Dict[str, Union[Type[Task], Type[Command]]] = {
-        '.foo': DummyAnalyser,
-        '.bar': DummyCommand
+        db = SqliteStateDatabase(tmp_path)
+        emap: Dict[str, Union[Type[Task], Type[Command]]] = {
+            '.foo': DummyTask
         }
-    queue = QueueManager(1)
-    test_unit = ExtensionVisitor(emap, {}, db, tmp_path, queue)
-    test_unit.visit(foo_file)
+        fmap: Dict[Type[Command], List[str]] = {}
+        queue = QueueManager(1)
+        test_unit = ExtensionVisitor(emap, fmap, db, tmp_path, queue)
+        tracker.clear()
+        test_unit.visit(tmp_path / 'test.foo')
+        assert tracker == [tmp_path / 'test.foo']
 
-    assert tracker['analyser'] == [foo_file]
-    assert file_info.get_file_info(foo_file) \
-        == FileInfo(foo_file, 345244617)
-    assert tracker['command'] == []
+        test_unit.visit(tmp_path / 'directory' / 'file.foo')
+        assert tracker == [tmp_path / 'test.foo',
+                           tmp_path / 'directory' / 'file.foo']
 
-    test_unit.visit(bar_file)
-    assert tracker['analyser'] == [foo_file]
-    assert file_info.get_file_info(foo_file) \
-        == FileInfo(foo_file, 345244617)
-    assert tracker['command'] == [bar_file]
-    assert file_info.get_file_info(bar_file) \
-        == FileInfo(bar_file, 2333477459)
+    def test_command(self, tmp_path: Path):
+        (tmp_path / 'test.bar').write_text("File the first")
+        (tmp_path / 'directory').mkdir()
+        (tmp_path / 'directory' / 'test.bar').write_text("File the second in directory")
 
-    # Baz doesn't exist, so we're expecting no change
-    test_unit.visit(baz_file)
-    assert tracker['analyser'] == [foo_file]
-    assert file_info.get_file_info(foo_file) \
-        == FileInfo(foo_file, 345244617)
-    assert tracker['command'] == [bar_file]
-    assert file_info.get_file_info(bar_file) \
-        == FileInfo(bar_file, 2333477459)
+        tracker: List[Path] = []
 
+        class DummyCommand(SingleFileCommand):
+            @property
+            def output(self) -> List[Path]:
+                return [Path(tmp_path / 'wiggins')]
 
-def test_nested_visit(tmp_path: Path):
-    tree_root = tmp_path / 'nested'
-    tree_root.mkdir()
-    foo_file = tree_root / 'file.foo'
-    foo_file.write_text('First file')
-    bar_file = tree_root / 'file.bar'
-    bar_file.write_text('Second file')
-    # This file doesn't exist - it will be created by the
-    # command task when run on the "bar" file
-    baz_file = tree_root / 'file.baz'
+            @property
+            def as_list(self) -> List[str]:
+                tracker.append(self._filename)
+                return ['cp', str(self._filename), str(self.output[0])]
 
-    db = SqliteStateDatabase(tmp_path)
-    file_info = FileInfoDatabase(db)
-
-    emap: Dict[str, Union[Type[Task], Type[Command]]] = {
-        '.foo': DummyAnalyser,
-        '.bar': DummyCommand,
-        '.baz': DummyAnalyser
+        db = SqliteStateDatabase(tmp_path)
+        emap: Dict[str, Union[Type[Task], Type[Command]]] = {
+            '.bar': DummyCommand
         }
-    queue = QueueManager(1)
-    visitor = ExtensionVisitor(emap, {}, db, tmp_path, queue)
-    test_unit = TreeDescent(tree_root)
-    test_unit.descend(visitor)
+        fmap: Dict[Type[Command], List[str]] = {}
+        queue = QueueManager(1)
+        test_unit = ExtensionVisitor(emap, fmap, db, tmp_path, queue)
+        tracker.clear()
+        test_unit.visit(tmp_path / 'test.bar')
+        assert tracker == [tmp_path / 'test.bar']
 
-    assert tracker['analyser'] == [foo_file, baz_file]
-    assert file_info.get_file_info(foo_file) \
-        == FileInfo(foo_file, 345244617)
-    assert file_info.get_file_info(baz_file) \
-        == FileInfo(baz_file, 411763741)
-    assert tracker['command'] == [bar_file]
-    assert file_info.get_file_info(bar_file) \
-        == FileInfo(bar_file, 411763741)
+        test_unit.visit(tmp_path / 'directory' / 'test.bar')
+        assert tracker == [tmp_path / 'test.bar',
+                           tmp_path / 'directory/test.bar']
+
+    def test_unrecognised_extension(self, tmp_path: Path):
+        (tmp_path / 'test.what').write_text('Some test file')
+
+        tracker: List[Path] = []
+
+        class DummyAnalyser(Analyser):
+            tracker: List[Path] = []
+
+            def run(self):
+                tracker.append(self._reader.filename)
+
+        db = SqliteStateDatabase(tmp_path)
+        emap: Dict[str, Union[Type[Task], Type[Command]]] = {
+            '.expected': DummyAnalyser
+        }
+        fmap: Dict[Type[Command], List[str]] = {}
+        queue = QueueManager(1)
+        test_unit = ExtensionVisitor(emap, fmap, db, tmp_path, queue)
+        tracker.clear()
+        test_unit.visit(tmp_path / 'test.what')
+        assert tracker == []
+
+    def test_bad_extension_map(self, tmp_path: Path):
+        (tmp_path / 'test.qux').write_text('Test file')
+
+        class WhatnowCommand(Command):
+            @property
+            def as_list(self) -> List[str]:
+                return []
+
+            @property
+            def output(self) -> List[Path]:
+                return []
+
+            @property
+            def input(self) -> List[Path]:
+                return []
+
+        db = SqliteStateDatabase(tmp_path)
+        emap: Dict[str, Union[Type[Task], Type[Command]]] = {
+            '.qux': WhatnowCommand,
+            }
+        fmap: Dict[Type[Command], List[str]] = {}
+        queue = QueueManager(1)
+        test_unit = ExtensionVisitor(emap, fmap, db, tmp_path, queue)
+        with pytest.raises(TypeError):
+            test_unit.visit(tmp_path / 'test.qux')
+
+
+class TestTreeDescent(object):
+    @pytest.fixture(scope='class',
+                    params=[None, 'nest'])
+    def root_dir(self, request):
+        yield request.param
+
+    class DummyVisitor(TreeVisitor):
+        def __init__(self, outfile: Path):
+            self._outfile = outfile
+            self.visited: List[Path] = []
+
+        def visit(self, candidate: Path) -> List[Path]:
+            self.visited.append(candidate)
+            return []
+
+        @property
+        def output(self) -> List[Path]:
+            return [self._outfile]
+
+    def test_descent(self, tmp_path: Path, root_dir):
+        if root_dir is not None:
+            tree_root = tmp_path / root_dir
+            tree_root.mkdir()
+        else:
+            tree_root = tmp_path
+        (tree_root / 'alpha').write_text('File in root')
+        (tree_root / 'beta').mkdir()
+        (tree_root / 'beta' / 'gamma').write_text('File in beta')
+        (tree_root / 'beta' / 'delta').write_text('Another file in beta')
+
+        test_unit = TreeDescent(tree_root)
+        visitor = self.DummyVisitor(tmp_path / 'foo')
+        test_unit.descend(visitor)
+
+        assert visitor.visited == [tree_root / 'beta' / 'gamma',
+                                   tree_root / 'beta' / 'delta',
+                                   tree_root / 'alpha']

--- a/unit-tests/source_tree_test.py
+++ b/unit-tests/source_tree_test.py
@@ -4,7 +4,7 @@
 # which you should have received as part of this distribution
 ##############################################################################
 from pathlib import Path
-import pytest
+import pytest  # type: ignore
 from typing import Union, List, Dict, Type
 
 from fab.database import SqliteStateDatabase
@@ -17,7 +17,8 @@ class TestExtensionVisitor(object):
     def test_analyser(self, tmp_path: Path):
         (tmp_path / 'test.foo').write_text("First file")
         (tmp_path / 'directory').mkdir()
-        (tmp_path / 'directory' / 'file.foo').write_text("Second file in directory")
+        (tmp_path / 'directory' / 'file.foo')\
+            .write_text("Second file in directory")
 
         tracker: List[Path] = []
 
@@ -43,7 +44,8 @@ class TestExtensionVisitor(object):
     def test_command(self, tmp_path: Path):
         (tmp_path / 'test.bar').write_text("File the first")
         (tmp_path / 'directory').mkdir()
-        (tmp_path / 'directory' / 'test.bar').write_text("File the second in directory")
+        (tmp_path / 'directory' / 'test.bar') \
+            .write_text("File the second in directory")
 
         tracker: List[Path] = []
 


### PR DESCRIPTION
This is a reconstruction of my previous branch (#49) to extend unit test coverage. Due to cuffing up a `git rebase` I had to start again from scratch.

As per the previous request: These changes push our unit test coverage as far as it can reasonably go.

I don't think it makes sense to test our abstract types to ensure they are properly abstract. It is a shortcoming in Python that they might not be but I think we can safely put that off until we have spare time.

A few minor issues have been fixed as they were discovered while developing the tests.