### PR TITLE
Possible method for allowing the tree descent to utilise the queue

### DIFF
--- a/source/fab/application.py
+++ b/source/fab/application.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import sys
 from typing import Dict, List, Type, Union
 
-from fab.database import SqliteStateDatabase
+from fab.database import SqliteStateDatabase, FileInfoDatabase
 from fab.language import \
     Task, \
     Command, \
@@ -18,7 +18,7 @@ from fab.language.fortran import \
     FortranPreProcessor, \
     FortranCompiler, \
     FortranLinker
-from fab.source_tree import TreeDescent, ExtensionVisitor, FileInfoDatabase
+from fab.source_tree import TreeDescent, ExtensionVisitor
 from fab.queue import QueueManager
 
 

--- a/source/fab/application.py
+++ b/source/fab/application.py
@@ -40,7 +40,6 @@ class Fab(object):
                  ld_flags: str,
                  n_procs: int):
 
-        self._state = SqliteStateDatabase(workspace)
         self._workspace = workspace
         self._target = target
         self._exec_name = exec_name
@@ -58,7 +57,8 @@ class Fab(object):
             self._command_flags_map[FortranLinker] = (
                 ld_flags.split()
             )
-        self._queue = QueueManager(n_procs - 1)
+        self._queue = QueueManager(n_procs - 1, workspace)
+        self._state = SqliteStateDatabase(workspace, self._queue._lock)
 
     def run(self, source: Path):
 

--- a/source/fab/language/__init__.py
+++ b/source/fab/language/__init__.py
@@ -34,13 +34,12 @@ class Task(ABC):
 
 
 class Analyser(Task, ABC):
-    def __init__(self, reader: TextReader, database: StateDatabase):
-        self._database = database
+    def __init__(self, reader: TextReader):
         self._reader = reader
 
-    @property
-    def database(self):
-        return self._database
+    @abstractmethod
+    def run(self, database: StateDatabase = None) -> None:
+        raise NotImplementedError('Abstract methods must be implemented')
 
     @property
     def prerequisites(self) -> List[Path]:

--- a/source/fab/language/fortran.py
+++ b/source/fab/language/fortran.py
@@ -21,7 +21,6 @@ from typing import (Generator,
 from fab.database import (DatabaseDecorator,
                           FileInfoDatabase,
                           StateDatabase,
-                          SqliteStateDatabase,
                           WorkingStateException)
 from fab.language import \
     Analyser, \
@@ -295,8 +294,11 @@ class FortranAnalyser(Analyser):
     _end_block_pattern: Pattern = re.compile(_end_block_re, re.IGNORECASE)
     _use_pattern: Pattern = re.compile(_use_statement_re, re.IGNORECASE)
 
-    def run(self, database: SqliteStateDatabase):
+    def run(self, database: StateDatabase = None):
         logger = logging.getLogger(__name__)
+
+        if database is None:
+            raise TaskException("Analyser called without database")
 
         state = FortranWorkingState(database)
 

--- a/source/fab/queue.py
+++ b/source/fab/queue.py
@@ -10,7 +10,7 @@ from typing import List
 from pathlib import Path
 from multiprocessing import Queue, JoinableQueue, Process, Lock
 from multiprocessing.synchronize import Lock as LockT
-from fab.language import Task, Analyser
+from fab.language import Task, Analyser, HashCalculator
 from fab.database import SqliteStateDatabase
 
 
@@ -35,7 +35,7 @@ def worker(queue: JoinableQueue, lock: LockT, workspace: Path):
         if isinstance(task, StopTask):
             break
         if all([prereq.exists() for prereq in task.prerequisites]):
-            if isinstance(task, Analyser):
+            if isinstance(task, (Analyser, HashCalculator)):
                 task.run(database)
             else:
                 task.run()

--- a/source/fab/reader.py
+++ b/source/fab/reader.py
@@ -25,16 +25,22 @@ class TextReader(ABC):
 class FileTextReader(TextReader):
     def __init__(self, filename: Path):
         self._filename: Path = filename
-        self._handle: IO[Text] = self._filename.open(encoding='utf-8')
+        self._handle = None
 
     def __del__(self):
         self._handle.close()
+
+    def open(self):
+        if self._handle is None:
+            self._handle: IO[Text] = \
+                self._filename.open(encoding='utf-8')
 
     @property
     def filename(self):
         return self._filename
 
     def line_by_line(self):
+        self.open()
         for line in self._handle.readlines():
             yield line
 

--- a/source/fab/source_tree.py
+++ b/source/fab/source_tree.py
@@ -48,7 +48,7 @@ class ExtensionVisitor(TreeVisitor):
             hasher: TextReaderAdler32 = TextReaderAdler32(reader)
 
             if issubclass(task_class, Analyser):
-                task: Task = task_class(hasher, self._state)
+                task: Task = task_class(hasher)
             elif issubclass(task_class, SingleFileCommand):
                 flags = self._command_flags_map.get(task_class, [])
                 task = CommandTask(
@@ -57,16 +57,16 @@ class ExtensionVisitor(TreeVisitor):
                 message = \
                     f'Unhandled class "{task_class}" in extension map.'
                 raise TypeError(message)
-            # TODO: Make SQLite connection multiprocess safe
-            # self._queue.add_to_queue(task)
-            task.run()
+
+            self._queue.add_to_queue(task)
+
             new_candidates.extend(task.products)
             # TODO: The hasher part here likely needs to be
             #       moved once the task is run by the queue
-            for _ in hasher.line_by_line():
-                pass  # Make sure we've read the whole file.
-            file_info = FileInfoDatabase(self._state)
-            file_info.add_file_info(candidate, hasher.hash)
+            #for _ in hasher.line_by_line():
+            #    pass  # Make sure we've read the whole file.
+            #file_info = FileInfoDatabase(self._state)
+            #file_info.add_file_info(candidate, hasher.hash)
         except KeyError:
             pass
         return new_candidates

--- a/source/fab/source_tree.py
+++ b/source/fab/source_tree.py
@@ -10,13 +10,14 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Mapping, List, Union, Type
 
-from fab.database import FileInfoDatabase, SqliteStateDatabase
+from fab.database import SqliteStateDatabase
 from fab.language import \
     Task, \
     Analyser, \
     CommandTask, \
     Command, \
-    SingleFileCommand
+    SingleFileCommand, \
+    HashCalculator
 from fab.reader import TextReader, FileTextReader, TextReaderAdler32
 from fab.queue import QueueManager
 
@@ -59,14 +60,10 @@ class ExtensionVisitor(TreeVisitor):
                 raise TypeError(message)
 
             self._queue.add_to_queue(task)
+            self._queue.add_to_queue(HashCalculator(hasher))
 
             new_candidates.extend(task.products)
-            # TODO: The hasher part here likely needs to be
-            #       moved once the task is run by the queue
-            #for _ in hasher.line_by_line():
-            #    pass  # Make sure we've read the whole file.
-            #file_info = FileInfoDatabase(self._state)
-            #file_info.add_file_info(candidate, hasher.hash)
+
         except KeyError:
             pass
         return new_candidates


### PR DESCRIPTION
Whilst working on #50 it emerged that the source tree descent didn't play nicely with the `multiprocessing` module (owing mostly to the need to serialise objects, which doesn't work naturally with active database or file objects).  This proposes some ideas for how we might be able to get this to work

 - For the database we allow each queue worker to have its own database connection, which gets passed to certain types of `Task` via their `run` method.  This also requires a locking mechanism to protect the database from clashing commits

 - For the files it is slightly simpler - we just have to defer the opening of the file until access is needed (rather than on construction)

Technically the latter approach _could_ also be used for the databases (if we were happy with the performance of creating connections repeatedly like that).

The `mypy` type checking and unit tests are at present completely broken, as I'd like to see whether we think this approach is reasonable before updating them.  But the system tests pass (you can confirm by checking out the branch and running)
