### PR TITLE
Modify FileTextReader so that it opens files on-demand

### DIFF
--- a/source/fab/reader.py
+++ b/source/fab/reader.py
@@ -25,16 +25,23 @@ class TextReader(ABC):
 class FileTextReader(TextReader):
     def __init__(self, filename: Path):
         self._filename: Path = filename
-        self._handle: IO[Text] = self._filename.open(encoding='utf-8')
+        self._handle = None
 
     def __del__(self):
-        self._handle.close()
+        if self._handle is not None:
+            self._handle.close()
+
+    def open(self):
+        if self._handle is None:
+            self._handle: IO[Text] = \
+                self._filename.open(encoding='utf-8')
 
     @property
     def filename(self):
         return self._filename
 
     def line_by_line(self):
+        self.open()
         for line in self._handle.readlines():
             yield line
 

--- a/source/fab/reader.py
+++ b/source/fab/reader.py
@@ -31,18 +31,19 @@ class FileTextReader(TextReader):
         if self._handle is not None:
             self._handle.close()
 
-    def open(self):
+    def get_handle(self):
         if self._handle is None:
             self._handle: IO[Text] = \
                 self._filename.open(encoding='utf-8')
+        return self._handle
 
     @property
     def filename(self):
         return self._filename
 
     def line_by_line(self):
-        self.open()
-        for line in self._handle.readlines():
+        handle = self.get_handle()
+        for line in handle.readlines():
             yield line
 
 


### PR DESCRIPTION
As part of trying to make the tree descent multiprocess-safe it has emerged that it would be better if the `FileTextReader` waited to open files until they are actually needed for the first time.  A functionally null change as far as this PR is concerned, but will eventually mean that any worker process calling a `Task` that requires an instance of this class will open its own copy of the file.