### PR TITLE
Make the database connection "on demand"

### DIFF
--- a/Experimental/BigTestProject/generate_project
+++ b/Experimental/BigTestProject/generate_project
@@ -1,0 +1,61 @@
+#!/bin/bash
+##############################################################################
+# (c) Crown copyright Met Office. All rights reserved.
+# For further details please refer to the file COPYRIGHT
+# which you should have received as part of this distribution
+##############################################################################
+#
+# This file generates a pretend project aimed at being used to run tests on
+# the core mechanics of Fab - set the value of N below to determine the size
+# of the test project.  
+#
+# It will produce:
+#  * 1 main program .F90 file
+#  * N module .F90 files each containing one subroutine
+#
+# All of these will depend on each other in a linear chain (i.e. main program
+# depends on module_1, module_1 depends on module_2, up to module_N) with each
+# layer simply calling the enclosed subroutine (until module_N which prints a
+# simple message)
+#
+# The files get created in the directory the script is run from, and you can
+# then point Fab at that directory to run the test.  The name of the main
+# program is "test" so (at time of writing) you would run it like this:
+# 
+#       fab test /path/to/big_project
+
+N=1000
+
+cat >> main.F90 <<EOF
+program test
+use module_1, ONLY: subroutine_1
+implicit none
+call subroutine_1()
+end program test
+EOF
+
+for i in $(seq 1 $((N-1))) ; do
+    j=$((i+1))
+    cat >> module_$i.F90 <<EOF
+module module_$i
+use module_$j, ONLY: subroutine_$j
+implicit none
+contains
+subroutine subroutine_$i
+implicit none
+call subroutine_$j()
+end subroutine subroutine_$i
+end module module_$i
+EOF
+done
+
+cat >> module_$N.F90 <<EOF
+module module_$N
+implicit none
+contains
+subroutine subroutine_$N
+implicit none
+print*, "We did it!"
+end subroutine subroutine_$N
+end module module_$N
+EOF

--- a/source/fab/application.py
+++ b/source/fab/application.py
@@ -43,8 +43,11 @@ class Fab(object):
                  ld_flags: str,
                  n_procs: int):
 
-        self._state = SqliteStateDatabase(workspace)
         self._workspace = workspace
+        if not workspace.exists():
+            workspace.mkdir(parents=True)
+
+        self._state = SqliteStateDatabase(workspace)
         self._target = target
         self._exec_name = exec_name
 

--- a/source/fab/database.py
+++ b/source/fab/database.py
@@ -112,9 +112,6 @@ class SqliteStateDatabase(StateDatabase):
 
     def get_connection(self) -> sqlite3.Connection:
         if self._connection is None:
-            if not self._working_directory.exists():
-                self._working_directory.mkdir(parents=True)
-
             self._connection \
                 = sqlite3.connect(str(self._working_directory / 'state.db'))
             self._connection.row_factory = sqlite3.Row

--- a/source/fab/database.py
+++ b/source/fab/database.py
@@ -104,19 +104,25 @@ class SqliteStateDatabase(StateDatabase):
     '''
     def __init__(self, working_directory: Path):
         self._working_directory: Path = working_directory
-
-        if not self._working_directory.exists():
-            self._working_directory.mkdir(parents=True)
-
-        self._connection: sqlite3.Connection \
-            = sqlite3.connect(str(working_directory / 'state.db'))
-        self._connection.row_factory = sqlite3.Row
+        self._connection: Optional[sqlite3.Connection] = None
 
     def __del__(self):
-        self._connection.close()
+        if self._connection is not None:
+            self._connection.close()
+
+    def get_connection(self) -> sqlite3.Connection:
+        if self._connection is None:
+            if not self._working_directory.exists():
+                self._working_directory.mkdir(parents=True)
+
+            self._connection \
+                = sqlite3.connect(str(self._working_directory / 'state.db'))
+            self._connection.row_factory = sqlite3.Row
+        return self._connection
 
     def execute(self, query: Union[Sequence[str], str],
                 inserts: Dict[str, str]) -> DatabaseRows:
+        connection = self.get_connection()
         if isinstance(query, str):
             query_list: Sequence[str] = [query]
         else:
@@ -124,7 +130,7 @@ class SqliteStateDatabase(StateDatabase):
 
         cursor = None
         for command in query_list:
-            cursor = self._connection.execute(command, inserts)
-        self._connection.commit()
+            cursor = connection.execute(command, inserts)
+        connection.commit()
 
         return DatabaseRows(cursor)

--- a/source/fab/database.py
+++ b/source/fab/database.py
@@ -110,7 +110,7 @@ class SqliteStateDatabase(StateDatabase):
         if self._connection is not None:
             self._connection.close()
 
-    def get_connection(self) -> sqlite3.Connection:
+    def _get_connection(self) -> sqlite3.Connection:
         if self._connection is None:
             self._connection \
                 = sqlite3.connect(str(self._working_directory / 'state.db'))
@@ -119,7 +119,7 @@ class SqliteStateDatabase(StateDatabase):
 
     def execute(self, query: Union[Sequence[str], str],
                 inserts: Dict[str, str]) -> DatabaseRows:
-        connection = self.get_connection()
+        connection = self._get_connection()
         if isinstance(query, str):
             query_list: Sequence[str] = [query]
         else:

--- a/unit-tests/database_test.py
+++ b/unit-tests/database_test.py
@@ -79,7 +79,15 @@ class TestDatabaseRows(object):
 
 class TestSQLiteStateDatabase(object):
     def test_constructor(self, tmp_path: Path):
-        _ = SqliteStateDatabase(tmp_path)
+        database = SqliteStateDatabase(tmp_path)
+
+        assert database._connection is None
+        assert database._working_directory == tmp_path
+
+    def test_connector(self, tmp_path: Path):
+        database = SqliteStateDatabase(tmp_path)
+
+        _ = database.get_connection()
 
         db_file = tmp_path / 'state.db'
         assert db_file.exists()
@@ -88,7 +96,9 @@ class TestSQLiteStateDatabase(object):
         connection = sqlite3.Connection(str(db_file))
         connection.close()
 
-        _ = SqliteStateDatabase(tmp_path / 'extra')
+        database = SqliteStateDatabase(tmp_path / 'extra')
+
+        _ = database.get_connection()
 
         db_file = tmp_path / 'extra' / 'state.db'
         assert db_file.exists()

--- a/unit-tests/database_test.py
+++ b/unit-tests/database_test.py
@@ -96,6 +96,7 @@ class TestSQLiteStateDatabase(object):
         connection = sqlite3.Connection(str(db_file))
         connection.close()
 
+        (tmp_path / 'extra').mkdir()
         database = SqliteStateDatabase(tmp_path / 'extra')
 
         _ = database.get_connection()

--- a/unit-tests/database_test.py
+++ b/unit-tests/database_test.py
@@ -81,12 +81,27 @@ class TestSQLiteStateDatabase(object):
     def test_creation(self, tmp_path: Path):
         database = SqliteStateDatabase(tmp_path)
 
-        database.execute('''create table test_table
+        database.execute('''create table first_table
                             (anything integer)''', {})
 
         # Issuing a query should have created the database
         db_file = tmp_path / 'state.db'
         assert db_file.exists()
+
+        # A second execute should work with no issue
+        database.execute('''create table second_table
+                            (anything integer)''', {})
+
+        # Since the connection should persist, removing
+        # the database at this point should cause an error
+        # when another execute is raised
+        db_file.unlink()
+        with pytest.raises(sqlite3.OperationalError):
+            database.execute('''create table third_table
+                                (anything integer)''', {})
+
+        # And it shouldn't have created the database again
+        assert not db_file.exists()
 
 
 class TestFileInfoDatabase(object):

--- a/unit-tests/database_test.py
+++ b/unit-tests/database_test.py
@@ -78,35 +78,15 @@ class TestDatabaseRows(object):
 
 
 class TestSQLiteStateDatabase(object):
-    def test_constructor(self, tmp_path: Path):
+    def test_creation(self, tmp_path: Path):
         database = SqliteStateDatabase(tmp_path)
 
-        assert database._connection is None
-        assert database._working_directory == tmp_path
+        database.execute('''create table test_table
+                            (anything integer)''', {})
 
-    def test_connector(self, tmp_path: Path):
-        database = SqliteStateDatabase(tmp_path)
-
-        _ = database.get_connection()
-
+        # Issuing a query should have created the database
         db_file = tmp_path / 'state.db'
         assert db_file.exists()
-
-        # Check we can open the database without exceptions
-        connection = sqlite3.Connection(str(db_file))
-        connection.close()
-
-        (tmp_path / 'extra').mkdir()
-        database = SqliteStateDatabase(tmp_path / 'extra')
-
-        _ = database.get_connection()
-
-        db_file = tmp_path / 'extra' / 'state.db'
-        assert db_file.exists()
-
-        # Check we can open the database without exceptions
-        connection = sqlite3.Connection(str(db_file))
-        connection.close()
 
 
 class TestFileInfoDatabase(object):


### PR DESCRIPTION
To try and enable us to utilise the queue for the source tree descent this proposes a way to make the database connection object only open once an Analyser Task needs to make use of it.  This plays into the way `multiprocessing` works as you cannot pass "live" connections to parallel workers.

However, doing things this way comes at a slight cost - there is some overhead in initialising a connection object (rather than re-using one which was previously opened).  The hope is that being able to utilise multiple workers in the source tree descent offers enough of a benefit on its own that any slight extra overhead in the workers having to create connections becomes worth it