### PR TITLE
Enable queueing in the tree descent

### DIFF
--- a/source/fab/application.py
+++ b/source/fab/application.py
@@ -13,7 +13,8 @@ from fab.database import SqliteStateDatabase, FileInfoDatabase
 from fab.explorer import ExplorerWindow
 from fab.tasks import \
     Task, \
-    Command, \
+    Command
+from fab.tasks.common import \
     CommandTask
 from fab.tasks.fortran import \
     FortranAnalyser, \

--- a/source/fab/application.py
+++ b/source/fab/application.py
@@ -9,9 +9,12 @@ import sys
 from typing import Dict, List, Type, Union
 
 from fab import FabException
-from fab.database import SqliteStateDatabase
+from fab.database import SqliteStateDatabase, FileInfoDatabase
 from fab.explorer import ExplorerWindow
-from fab.language import Task, Command, CommandTask
+from fab.language import \
+    Task, \
+    Command, \
+    CommandTask
 from fab.language.fortran import \
     FortranAnalyser, \
     FortranWorkingState, \
@@ -19,7 +22,7 @@ from fab.language.fortran import \
     FortranUnitID, \
     FortranCompiler, \
     FortranLinker
-from fab.source_tree import TreeDescent, ExtensionVisitor, FileInfoDatabase
+from fab.source_tree import TreeDescent, ExtensionVisitor
 from fab.queue import QueueManager
 
 

--- a/source/fab/application.py
+++ b/source/fab/application.py
@@ -11,11 +11,11 @@ from typing import Dict, List, Type, Union
 from fab import FabException
 from fab.database import SqliteStateDatabase, FileInfoDatabase
 from fab.explorer import ExplorerWindow
-from fab.language import \
+from fab.tasks import \
     Task, \
     Command, \
     CommandTask
-from fab.language.fortran import \
+from fab.tasks.fortran import \
     FortranAnalyser, \
     FortranWorkingState, \
     FortranPreProcessor, \

--- a/source/fab/application.py
+++ b/source/fab/application.py
@@ -72,14 +72,11 @@ class Fab(object):
 
         self._queue.run()
 
-        # TODO: This is where the threads first separate
-        #       master thread stays to manage queue workers.
-        #       One thread performs descent below.
         visitor = ExtensionVisitor(self._extension_map,
                                    self._command_flags_map,
                                    self._state,
                                    self._workspace,
-                                   self._queue)
+                                   self._queue.add_to_queue)
         descender = TreeDescent(source)
         descender.descend(visitor)
 

--- a/source/fab/explorer.py
+++ b/source/fab/explorer.py
@@ -13,7 +13,7 @@ import tkinter.ttk as ttk
 from typing import Dict
 
 from fab.database import FileInfoDatabase, StateDatabase
-from fab.language.fortran import FortranWorkingState
+from fab.tasks.fortran import FortranWorkingState
 
 
 class ExplorerWindow(tk.Frame):

--- a/source/fab/language/__init__.py
+++ b/source/fab/language/__init__.py
@@ -9,8 +9,8 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import List
 
-from fab.database import StateDatabase
-from fab.reader import TextReader
+from fab.database import StateDatabase, FileInfoDatabase
+from fab.reader import TextReader, TextReaderAdler32
 
 
 class TaskException(Exception):
@@ -35,8 +35,8 @@ class Task(ABC):
 
 class Analyser(Task, ABC):
     def __init__(self, reader: TextReader, database: StateDatabase):
-        self._database = database
         self._reader = reader
+        self._database = database
 
     @property
     def database(self):
@@ -46,6 +46,30 @@ class Analyser(Task, ABC):
     def prerequisites(self) -> List[Path]:
         if isinstance(self._reader.filename, Path):
             return [self._reader.filename]
+        else:
+            return []
+
+    @property
+    def products(self) -> List[Path]:
+        return []
+
+
+class HashCalculator(Task):
+    def __init__(self, hasher: TextReaderAdler32, database: StateDatabase):
+        self._hasher = hasher
+        self._database = database
+
+    def run(self):
+        for _ in self._hasher.line_by_line():
+            pass  # Make sure we've read the whole file
+        file_info = FileInfoDatabase(self._database)
+        file_info.add_file_info(Path(self._hasher.filename),
+                                self._hasher.hash)
+
+    @property
+    def prerequisites(self) -> List[Path]:
+        if isinstance(self._hasher.filename, Path):
+            return [self._hasher.filename]
         else:
             return []
 

--- a/source/fab/queue.py
+++ b/source/fab/queue.py
@@ -8,7 +8,7 @@ Classes and methods relating to the queue system
 '''
 from typing import List
 from multiprocessing import Queue, JoinableQueue, Process
-from fab.language import Task
+from fab.tasks import Task
 
 
 class StopTask(Task):

--- a/source/fab/reader.py
+++ b/source/fab/reader.py
@@ -6,7 +6,6 @@
 from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import IO, Iterator, List, Text, Union
-from zlib import adler32
 
 
 class TextReader(ABC):
@@ -68,18 +67,3 @@ class TextReaderDecorator(TextReader, ABC):
     @property
     def filename(self):
         return self._source.filename
-
-
-class TextReaderAdler32(TextReaderDecorator):
-    def __init__(self, source: TextReader):
-        super().__init__(source)
-        self._hash = 1
-
-    @property
-    def hash(self):
-        return self._hash
-
-    def line_by_line(self):
-        for line in self._source.line_by_line():
-            self._hash = adler32(bytes(line, encoding='utf-8'), self._hash)
-            yield line

--- a/source/fab/source_tree.py
+++ b/source/fab/source_tree.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from typing import Mapping, List, Union, Type
 
 from fab.database import SqliteStateDatabase
-from fab.language import \
+from fab.tasks import \
     Task, \
     Analyser, \
     CommandTask, \

--- a/source/fab/source_tree.py
+++ b/source/fab/source_tree.py
@@ -8,7 +8,7 @@ Descend a directory tree or trees processing source files found along the way.
 '''
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Mapping, List, Union, Type
+from typing import Mapping, List, Union, Type, Callable
 
 from fab.database import SqliteStateDatabase
 from fab.tasks import \
@@ -20,7 +20,6 @@ from fab.tasks.common import \
     CommandTask, \
     HashCalculator
 from fab.reader import TextReader, FileTextReader
-from fab.queue import QueueManager
 
 
 class TreeVisitor(ABC):
@@ -35,12 +34,12 @@ class ExtensionVisitor(TreeVisitor):
                  command_flags_map: Mapping[Type[Command], List[str]],
                  state: SqliteStateDatabase,
                  workspace: Path,
-                 queue: QueueManager):
+                 task_handler: Callable):
         self._extension_map = extension_map
         self._command_flags_map = command_flags_map
         self._state = state
         self._workspace = workspace
-        self._queue = queue
+        self._task_handler = task_handler
 
     def visit(self, candidate: Path) -> List[Path]:
         new_candidates: List[Path] = []
@@ -59,8 +58,8 @@ class ExtensionVisitor(TreeVisitor):
                     f'Unhandled class "{task_class}" in extension map.'
                 raise TypeError(message)
 
-            self._queue.add_to_queue(task)
-            self._queue.add_to_queue(HashCalculator(reader, self._state))
+            self._task_handler(task)
+            self._task_handler(HashCalculator(reader, self._state))
 
             new_candidates.extend(task.products)
 

--- a/source/fab/source_tree.py
+++ b/source/fab/source_tree.py
@@ -14,9 +14,10 @@ from fab.database import SqliteStateDatabase
 from fab.tasks import \
     Task, \
     Analyser, \
-    CommandTask, \
     Command, \
-    SingleFileCommand, \
+    SingleFileCommand
+from fab.tasks.common import \
+    CommandTask, \
     HashCalculator
 from fab.reader import TextReader, FileTextReader, TextReaderAdler32
 from fab.queue import QueueManager

--- a/source/fab/tasks/__init__.py
+++ b/source/fab/tasks/__init__.py
@@ -2,15 +2,14 @@
 # For further details please refer to the file COPYRIGHT
 # which you should have received as part of this distribution
 '''
-Classes for defining the main task units run by Fab.
+Base classes for defining the main task units run by Fab.
 '''
-import subprocess
 from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import List
 
-from fab.database import StateDatabase, FileInfoDatabase
-from fab.reader import TextReader, TextReaderAdler32
+from fab.database import StateDatabase
+from fab.reader import TextReader
 
 
 class TaskException(Exception):
@@ -54,30 +53,6 @@ class Analyser(Task, ABC):
         return []
 
 
-class HashCalculator(Task):
-    def __init__(self, hasher: TextReaderAdler32, database: StateDatabase):
-        self._hasher = hasher
-        self._database = database
-
-    def run(self):
-        for _ in self._hasher.line_by_line():
-            pass  # Make sure we've read the whole file
-        file_info = FileInfoDatabase(self._database)
-        file_info.add_file_info(Path(self._hasher.filename),
-                                self._hasher.hash)
-
-    @property
-    def prerequisites(self) -> List[Path]:
-        if isinstance(self._hasher.filename, Path):
-            return [self._hasher.filename]
-        else:
-            return []
-
-    @property
-    def products(self) -> List[Path]:
-        return []
-
-
 class Command(ABC):
     def __init__(self, workspace: Path, flags: List[str], stdout=False):
         self._workspace = workspace
@@ -112,26 +87,3 @@ class SingleFileCommand(Command, ABC):
     @property
     def input(self) -> List[Path]:
         return [self._filename]
-
-
-class CommandTask(Task):
-    def __init__(self, command: Command):
-        self._command = command
-
-    def run(self):
-        if self._command.stdout:
-            process = subprocess.run(self._command.as_list,
-                                     check=True,
-                                     stdout=subprocess.PIPE)
-            with self._command.output[0].open('wb') as out_file:
-                out_file.write(process.stdout)
-        else:
-            _ = subprocess.run(self._command.as_list, check=True)
-
-    @property
-    def prerequisites(self) -> List[Path]:
-        return self._command.input
-
-    @property
-    def products(self) -> List[Path]:
-        return self._command.output

--- a/source/fab/tasks/__init__.py
+++ b/source/fab/tasks/__init__.py
@@ -2,7 +2,7 @@
 # For further details please refer to the file COPYRIGHT
 # which you should have received as part of this distribution
 '''
-Modules for handling different program languages appear in this package.
+Classes for defining the main task units run by Fab.
 '''
 import subprocess
 from abc import ABC, abstractmethod

--- a/source/fab/tasks/common.py
+++ b/source/fab/tasks/common.py
@@ -1,0 +1,60 @@
+# (c) Crown copyright Met Office. All rights reserved.
+# For further details please refer to the file COPYRIGHT
+# which you should have received as part of this distribution
+'''
+Tasks which are not language specific.
+'''
+import subprocess
+from typing import List
+from pathlib import Path
+
+from fab.tasks import Task, Command
+from fab.database import StateDatabase, FileInfoDatabase
+from fab.reader import TextReaderAdler32
+
+
+class HashCalculator(Task):
+    def __init__(self, hasher: TextReaderAdler32, database: StateDatabase):
+        self._hasher = hasher
+        self._database = database
+
+    def run(self):
+        for _ in self._hasher.line_by_line():
+            pass  # Make sure we've read the whole file
+        file_info = FileInfoDatabase(self._database)
+        file_info.add_file_info(Path(self._hasher.filename),
+                                self._hasher.hash)
+
+    @property
+    def prerequisites(self) -> List[Path]:
+        if isinstance(self._hasher.filename, Path):
+            return [self._hasher.filename]
+        else:
+            return []
+
+    @property
+    def products(self) -> List[Path]:
+        return []
+
+
+class CommandTask(Task):
+    def __init__(self, command: Command):
+        self._command = command
+
+    def run(self):
+        if self._command.stdout:
+            process = subprocess.run(self._command.as_list,
+                                     check=True,
+                                     stdout=subprocess.PIPE)
+            with self._command.output[0].open('wb') as out_file:
+                out_file.write(process.stdout)
+        else:
+            _ = subprocess.run(self._command.as_list, check=True)
+
+    @property
+    def prerequisites(self) -> List[Path]:
+        return self._command.input
+
+    @property
+    def products(self) -> List[Path]:
+        return self._command.output

--- a/source/fab/tasks/fortran.py
+++ b/source/fab/tasks/fortran.py
@@ -22,7 +22,7 @@ from fab.database import (DatabaseDecorator,
                           StateDatabase,
                           SqliteStateDatabase,
                           WorkingStateException)
-from fab.language import \
+from fab.tasks import \
     Analyser, \
     TaskException, \
     Command, \

--- a/unit-tests/queue_test.py
+++ b/unit-tests/queue_test.py
@@ -5,7 +5,7 @@
 ##############################################################################
 
 from fab.queue import QueueManager
-from fab.language import Task
+from fab.tasks import Task
 from pathlib import Path
 import os
 

--- a/unit-tests/reader_test.py
+++ b/unit-tests/reader_test.py
@@ -8,7 +8,7 @@ from textwrap import dedent
 
 from pytest import fail  # type: ignore
 
-from fab.reader import FileTextReader, StringTextReader, TextReaderAdler32
+from fab.reader import FileTextReader, StringTextReader
 
 
 class TestFileTextReader:
@@ -51,19 +51,6 @@ class TestStringTextReader:
         content = [line for line in test_unit.line_by_line()]
         assert content == ['This is my test file\n',
                            'It has two lines']
-
-        # Call again on a now read file...
-        for _ in test_unit.line_by_line():
-            fail(' No lines should be generated from a read file')
-
-
-class TestTextReaderAdler32:
-    def test_all(self):
-        source = StringTextReader('Bibble\nBobble babble\n')
-        test_unit = TextReaderAdler32(source)
-        content = [line for line in test_unit.line_by_line()]
-        assert content == ['Bibble\n', 'Bobble babble\n']
-        assert test_unit.hash == 1329530643
 
         # Call again on a now read file...
         for _ in test_unit.line_by_line():

--- a/unit-tests/source_tree_test.py
+++ b/unit-tests/source_tree_test.py
@@ -12,6 +12,27 @@ from fab.language import Analyser, Command, SingleFileCommand, Task
 from fab.source_tree import ExtensionVisitor, TreeDescent, TreeVisitor
 from fab.queue import QueueManager
 
+from multiprocessing import Manager
+
+
+tracker = Manager().list()
+
+
+class DummyAnalyser(Analyser):
+    def run(self):
+        tracker.append(self._reader.filename)
+
+
+class DummyCommand(SingleFileCommand):
+    @property
+    def output(self) -> List[Path]:
+        return [self._workspace / 'wiggins']
+
+    @property
+    def as_list(self) -> List[str]:
+        tracker.append(self._filename)
+        return ['cp', str(self._filename), str(self.output[0])]
+
 
 class TestExtensionVisitor(object):
     def test_analyser(self, tmp_path: Path):
@@ -20,26 +41,26 @@ class TestExtensionVisitor(object):
         (tmp_path / 'directory' / 'file.foo')\
             .write_text("Second file in directory")
 
-        tracker: List[Path] = []
-
-        class DummyTask(Analyser):
-            def run(self):
-                tracker.append(self._reader.filename)
-
         db = SqliteStateDatabase(tmp_path)
         emap: Dict[str, Union[Type[Task], Type[Command]]] = {
-            '.foo': DummyTask
+            '.foo': DummyAnalyser
         }
         fmap: Dict[Type[Command], List[str]] = {}
         queue = QueueManager(1)
+        queue.run()
         test_unit = ExtensionVisitor(emap, fmap, db, tmp_path, queue)
-        tracker.clear()
+
+        tracker[:] = []
+
         test_unit.visit(tmp_path / 'test.foo')
-        assert tracker == [tmp_path / 'test.foo']
+        queue.check_queue_done()
+        assert list(tracker) == [tmp_path / 'test.foo']
 
         test_unit.visit(tmp_path / 'directory' / 'file.foo')
-        assert tracker == [tmp_path / 'test.foo',
-                           tmp_path / 'directory' / 'file.foo']
+        queue.check_queue_done()
+        assert list(tracker) == [tmp_path / 'test.foo',
+                                 tmp_path / 'directory' / 'file.foo']
+        queue.shutdown()
 
     def test_command(self, tmp_path: Path):
         (tmp_path / 'test.bar').write_text("File the first")
@@ -47,43 +68,29 @@ class TestExtensionVisitor(object):
         (tmp_path / 'directory' / 'test.bar') \
             .write_text("File the second in directory")
 
-        tracker: List[Path] = []
-
-        class DummyCommand(SingleFileCommand):
-            @property
-            def output(self) -> List[Path]:
-                return [Path(tmp_path / 'wiggins')]
-
-            @property
-            def as_list(self) -> List[str]:
-                tracker.append(self._filename)
-                return ['cp', str(self._filename), str(self.output[0])]
-
         db = SqliteStateDatabase(tmp_path)
         emap: Dict[str, Union[Type[Task], Type[Command]]] = {
             '.bar': DummyCommand
         }
         fmap: Dict[Type[Command], List[str]] = {}
         queue = QueueManager(1)
+        queue.run()
         test_unit = ExtensionVisitor(emap, fmap, db, tmp_path, queue)
-        tracker.clear()
+
+        tracker[:] = []
+
         test_unit.visit(tmp_path / 'test.bar')
-        assert tracker == [tmp_path / 'test.bar']
+        queue.check_queue_done()
+        assert list(tracker) == [tmp_path / 'test.bar']
 
         test_unit.visit(tmp_path / 'directory' / 'test.bar')
-        assert tracker == [tmp_path / 'test.bar',
-                           tmp_path / 'directory/test.bar']
+        queue.check_queue_done()
+        assert list(tracker) == [tmp_path / 'test.bar',
+                                 tmp_path / 'directory/test.bar']
+        queue.shutdown()
 
     def test_unrecognised_extension(self, tmp_path: Path):
         (tmp_path / 'test.what').write_text('Some test file')
-
-        tracker: List[Path] = []
-
-        class DummyAnalyser(Analyser):
-            tracker: List[Path] = []
-
-            def run(self):
-                tracker.append(self._reader.filename)
 
         db = SqliteStateDatabase(tmp_path)
         emap: Dict[str, Union[Type[Task], Type[Command]]] = {
@@ -91,10 +98,16 @@ class TestExtensionVisitor(object):
         }
         fmap: Dict[Type[Command], List[str]] = {}
         queue = QueueManager(1)
+        queue.run()
         test_unit = ExtensionVisitor(emap, fmap, db, tmp_path, queue)
-        tracker.clear()
+
+        tracker[:] = []
+
         test_unit.visit(tmp_path / 'test.what')
-        assert tracker == []
+        queue.check_queue_done()
+        assert list(tracker) == []
+
+        queue.shutdown()
 
     def test_bad_extension_map(self, tmp_path: Path):
         (tmp_path / 'test.qux').write_text('Test file')

--- a/unit-tests/source_tree_test.py
+++ b/unit-tests/source_tree_test.py
@@ -8,7 +8,7 @@ import pytest  # type: ignore
 from typing import Union, List, Dict, Type
 
 from fab.database import SqliteStateDatabase
-from fab.language import Analyser, Command, SingleFileCommand, Task
+from fab.tasks import Analyser, Command, SingleFileCommand, Task
 from fab.source_tree import ExtensionVisitor, TreeDescent, TreeVisitor
 from fab.queue import QueueManager
 

--- a/unit-tests/tasks/__init__test.py
+++ b/unit-tests/tasks/__init__test.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import Union, Sequence, Dict, List
 
 from fab.database import DatabaseRows, StateDatabase
-from fab.tasks import Analyser, Command, CommandTask, SingleFileCommand
+from fab.tasks import Analyser, SingleFileCommand
 from fab.reader import FileTextReader, StringTextReader
 
 
@@ -54,63 +54,3 @@ class TestSingleFileCommand(object):
                                              Path('thing/otherthing'),
                                              ['beef', 'cheese'])
         assert test_unit.input == [Path('this/that')]
-
-
-class DummyCommand(Command):
-    def __init__(self, workspace: Path, flags: List[str], stdout: bool):
-        super().__init__(workspace, flags, stdout)
-        self._output = workspace / 'run.touch'
-
-    @property
-    def as_list(self) -> List[str]:
-        return ['touch', str(self._output)]
-
-    @property
-    def output(self) -> List[Path]:
-        return [Path('output')]
-
-    @property
-    def input(self) -> List[Path]:
-        return [Path('input')]
-
-
-class DummyTerminalCommand(Command):
-    def __init__(self, workspace: Path, flags: List[str], stdout: bool):
-        super().__init__(workspace, flags, stdout)
-        self._output = workspace / 'run.out'
-
-    @property
-    def as_list(self) -> List[str]:
-        return ['echo', 'run']
-
-    @property
-    def output(self) -> List[Path]:
-        return [self._output]
-
-    @property
-    def input(self) -> List[Path]:
-        return [Path('input')]
-
-
-class TestCommandTask(object):
-    def test_constructor(self):
-        test_unit = CommandTask(DummyCommand(Path('workspace'),
-                                             ['wargle', 'bargle'],
-                                             False))
-        assert test_unit.prerequisites == [Path('input')]
-        assert test_unit.products == [Path('output')]
-
-    def test_run_file_output(self, tmp_path: Path):
-        test_unit = CommandTask(DummyCommand(tmp_path,
-                                             ['wargle', 'bargle'],
-                                             False))
-        test_unit.run()
-        assert (tmp_path / 'run.touch').exists()
-
-    def test_run_terminal_output(self, tmp_path: Path):
-        test_unit = CommandTask(DummyTerminalCommand(tmp_path,
-                                                     ['wargle', 'bargle'],
-                                                     True))
-        test_unit.run()
-        assert (tmp_path / 'run.out').exists()
-        assert (tmp_path / 'run.out').read_text() == 'run\n'

--- a/unit-tests/tasks/__init__test.py
+++ b/unit-tests/tasks/__init__test.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import Union, Sequence, Dict, List
 
 from fab.database import DatabaseRows, StateDatabase
-from fab.language import Analyser, Command, CommandTask, SingleFileCommand
+from fab.tasks import Analyser, Command, CommandTask, SingleFileCommand
 from fab.reader import FileTextReader, StringTextReader
 
 

--- a/unit-tests/tasks/common_test.py
+++ b/unit-tests/tasks/common_test.py
@@ -1,0 +1,68 @@
+# (c) Crown copyright Met Office. All rights reserved.
+# For further details please refer to the file COPYRIGHT
+# which you should have received as part of this distribution
+from pathlib import Path
+from typing import List
+
+from fab.tasks import Command
+from fab.tasks.common import CommandTask
+
+
+class DummyCommand(Command):
+    def __init__(self, workspace: Path, flags: List[str], stdout: bool):
+        super().__init__(workspace, flags, stdout)
+        self._output = workspace / 'run.touch'
+
+    @property
+    def as_list(self) -> List[str]:
+        return ['touch', str(self._output)]
+
+    @property
+    def output(self) -> List[Path]:
+        return [Path('output')]
+
+    @property
+    def input(self) -> List[Path]:
+        return [Path('input')]
+
+
+class DummyTerminalCommand(Command):
+    def __init__(self, workspace: Path, flags: List[str], stdout: bool):
+        super().__init__(workspace, flags, stdout)
+        self._output = workspace / 'run.out'
+
+    @property
+    def as_list(self) -> List[str]:
+        return ['echo', 'run']
+
+    @property
+    def output(self) -> List[Path]:
+        return [self._output]
+
+    @property
+    def input(self) -> List[Path]:
+        return [Path('input')]
+
+
+class TestCommandTask(object):
+    def test_constructor(self):
+        test_unit = CommandTask(DummyCommand(Path('workspace'),
+                                             ['wargle', 'bargle'],
+                                             False))
+        assert test_unit.prerequisites == [Path('input')]
+        assert test_unit.products == [Path('output')]
+
+    def test_run_file_output(self, tmp_path: Path):
+        test_unit = CommandTask(DummyCommand(tmp_path,
+                                             ['wargle', 'bargle'],
+                                             False))
+        test_unit.run()
+        assert (tmp_path / 'run.touch').exists()
+
+    def test_run_terminal_output(self, tmp_path: Path):
+        test_unit = CommandTask(DummyTerminalCommand(tmp_path,
+                                                     ['wargle', 'bargle'],
+                                                     True))
+        test_unit.run()
+        assert (tmp_path / 'run.out').exists()
+        assert (tmp_path / 'run.out').read_text() == 'run\n'

--- a/unit-tests/tasks/fortran_test.py
+++ b/unit-tests/tasks/fortran_test.py
@@ -11,16 +11,17 @@ from typing import Iterator, Union
 import pytest  # type: ignore
 
 from fab.database import SqliteStateDatabase, WorkingStateException
-from fab.language import CommandTask, TaskException
-from fab.language.fortran import (FortranAnalyser,
-                                  FortranCompiler,
-                                  FortranInfo,
-                                  FortranLinker,
-                                  FortranNormaliser,
-                                  FortranPreProcessor,
-                                  FortranUnitID,
-                                  FortranUnitUnresolvedID,
-                                  FortranWorkingState)
+from fab.tasks import CommandTask, TaskException
+from fab.tasks.fortran import \
+    FortranAnalyser, \
+    FortranCompiler, \
+    FortranInfo, \
+    FortranLinker, \
+    FortranNormaliser, \
+    FortranPreProcessor, \
+    FortranUnitID, \
+    FortranUnitUnresolvedID, \
+    FortranWorkingState
 from fab.reader import FileTextReader, StringTextReader, TextReader
 
 

--- a/unit-tests/tasks/fortran_test.py
+++ b/unit-tests/tasks/fortran_test.py
@@ -11,7 +11,8 @@ from typing import Iterator, Union
 import pytest  # type: ignore
 
 from fab.database import SqliteStateDatabase, WorkingStateException
-from fab.tasks import CommandTask, TaskException
+from fab.tasks import TaskException
+from fab.tasks.common import CommandTask
 from fab.tasks.fortran import \
     FortranAnalyser, \
     FortranCompiler, \


### PR DESCRIPTION
Followup (and branch currently contains) #54 and #55 to actually make the source tree descent utilise the queue.  The missing piece of the puzzle being that the section which previously ensured that files passing through the descender were hashed can no longer live there (since that loop is now running asynchronously - it would try to hash files that don't yet exist).  The solution is to make the hashing part into another Task which gets added to the queue and depends on the main file whose task is being added.

Doing this also complicates the unit testing of the tree descent slightly - our existing tests were using locally defined classes (i.e. within the existing test routines) and were making use of a variable local to the text but external to those classes.  None of this works now because `multiprocessing` can't serialise locally defined classes, meaning they need to be global again, and making the external array global also fails due to being private to the worker executing the task.  Luckily the module provides a shared memory object that we can use to bypass this

Closes #52 and closes #27