### PR TITLE
Use the current directory as the default location for the working directory.

### DIFF
--- a/source/fab/entry.py
+++ b/source/fab/entry.py
@@ -71,7 +71,7 @@ def fab_entry() -> None:
         logger.setLevel(logging.WARNING)
 
     if not arguments.workspace:
-        arguments.workspace = arguments.source / 'working'
+        arguments.workspace = Path.cwd() / 'working'
 
     application = fab.application.Fab(arguments.workspace,
                                       arguments.target,


### PR DESCRIPTION
This is a very small change to harmonise the choice of default location for the working directory.

After some discussion it was decided that the currently selected directory should be the default.

Closes #59 