### PR TITLE
Remove hashing logic from ExtensionVisitor

### DIFF
--- a/source/fab/entry.py
+++ b/source/fab/entry.py
@@ -71,7 +71,7 @@ def fab_entry() -> None:
         logger.setLevel(logging.WARNING)
 
     if not arguments.workspace:
-        arguments.workspace = Path.cwd() / 'working'
+        arguments.workspace = arguments.source / 'working'
 
     application = fab.application.Fab(arguments.workspace,
                                       arguments.target,

--- a/source/fab/entry.py
+++ b/source/fab/entry.py
@@ -71,7 +71,7 @@ def fab_entry() -> None:
         logger.setLevel(logging.WARNING)
 
     if not arguments.workspace:
-        arguments.workspace = arguments.source / 'working'
+        arguments.workspace = Path.cwd() / 'working'
 
     application = fab.application.Fab(arguments.workspace,
                                       arguments.target,

--- a/source/fab/source_tree.py
+++ b/source/fab/source_tree.py
@@ -17,8 +17,7 @@ from fab.tasks import \
     Command, \
     SingleFileCommand
 from fab.tasks.common import \
-    CommandTask, \
-    HashCalculator
+    CommandTask
 from fab.reader import TextReader, FileTextReader
 
 
@@ -59,7 +58,6 @@ class ExtensionVisitor(TreeVisitor):
                 raise TypeError(message)
 
             self._task_handler(task)
-            self._task_handler(HashCalculator(reader, self._state))
 
             new_candidates.extend(task.products)
 

--- a/source/fab/source_tree.py
+++ b/source/fab/source_tree.py
@@ -3,9 +3,9 @@
 # For further details please refer to the file COPYRIGHT
 # which you should have received as part of this distribution
 ##############################################################################
-'''
+"""
 Descend a directory tree or trees processing source files found along the way.
-'''
+"""
 from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Mapping, List, Union, Type, Callable
@@ -25,7 +25,7 @@ from fab.reader import TextReader, FileTextReader
 class TreeVisitor(ABC):
     @abstractmethod
     def visit(self, candidate: Path) -> List[Path]:
-        raise NotImplementedError('Abstract method must be implemented')
+        raise NotImplementedError("Abstract method must be implemented")
 
 
 class ExtensionVisitor(TreeVisitor):
@@ -55,7 +55,7 @@ class ExtensionVisitor(TreeVisitor):
                     task_class(Path(reader.filename), self._workspace, flags))
             else:
                 message = \
-                    f'Unhandled class "{task_class}" in extension map.'
+                    f"Unhandled class '{task_class}' in extension map."
                 raise TypeError(message)
 
             self._task_handler(task)


### PR DESCRIPTION
I wasn't happy with ExtensionVisitor creating not only a task based on the extension but also a hashing task. I realised a simple solution to this was to move the logic to the application where I believe it belongs. This is achieved quite simply by interposing a function between the visitor and the queue.

Thus instead of directly adding tasks to the queue the visitor calls a function which does it, also adding a hashing task at the same time.

Closes #56 
