### PR TITLE
Application framework for fab-grab

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setuptools.setup(
     package_dir={'': 'source'},
     packages=setuptools.find_packages(where='source'),
     entry_points={'console_scripts': ['fab=fab.entry:fab_entry',
+                                      'fab-grab=fab.entry:grab_entry',
                                       'fab-dump=fab.entry:dump_entry'],
                   'gui_scripts': ['fab-explorer=fab.entry:fab_explorer']},
     python_requires='>=3.6, <4',

--- a/source/fab/application.py
+++ b/source/fab/application.py
@@ -6,7 +6,7 @@
 from collections import defaultdict
 from pathlib import Path
 import sys
-from typing import Dict, List, Type, Union
+from typing import Dict, List, Sequence, Type, Union
 
 from fab import FabException
 from fab.database import SqliteStateDatabase, FileInfoDatabase
@@ -187,6 +187,14 @@ class Fab(object):
         self._queue.add_to_queue(linker)
         self._queue.check_queue_done()
         self._queue.shutdown()
+
+
+class Grab(object):
+    def __init__(self, workspace: Path):
+        self._workspace = workspace
+
+    def run(self, repositories: Sequence[str]) -> None:
+        pass
 
 
 class Dump(object):


### PR DESCRIPTION
There's not a lot to this, it just creates a CLI for the new tool and hooks it into the setup script.

I would like to break appart the `application.py` module as a separate ticket so this change only relates to #62. It does not close it.
