### PR TITLE
Flip arguments to grabber

### DIFF
--- a/source/fab/grabber.py
+++ b/source/fab/grabber.py
@@ -36,11 +36,11 @@ def entry() -> None:
                         help="Print version identifier and exit.")
     parser.add_argument('-v', '--verbose', action='store_true',
                         help="Produce a running commentary on progress.")
-    parser.add_argument('repositories', metavar='URL', nargs='+',
-                        help="Location from which to extract source.")
     parser.add_argument('destination', metavar='PATH', type=Path,
                         default=Path.cwd() / 'source',
                         help="Source directory to create.")
+    parser.add_argument('repositories', metavar='URL', nargs='+',
+                        help="Location from which to extract source.")
 
     arguments = parser.parse_args()
 

--- a/system-tests/test.py
+++ b/system-tests/test.py
@@ -249,7 +249,7 @@ class RunGrab(EnterPython):
         super().__init__('grab',
                          test_directory,
                          'grabber',
-                         [repo_url, str(test_directory / 'working')],
+                         [str(test_directory / 'working'), repo_url],
                          working_dir=False)
 
     def description(self) -> str:


### PR DESCRIPTION
Make the open ended argument last on the list to avoid ambiguity.