### PR TITLE
Rework extension visitor to use pattern matching rather than extension

### DIFF
--- a/source/fab/builder.py
+++ b/source/fab/builder.py
@@ -6,7 +6,7 @@
 from collections import defaultdict
 import logging
 from pathlib import Path
-from typing import Dict, List, Type, Union
+from typing import Dict, List, Type, Union, Tuple
 from re import match
 
 from fab import FabException
@@ -94,13 +94,13 @@ def entry() -> None:
 
 
 class Fab(object):
-    _precompile_map: Dict[str, Union[Type[Task], Type[Command]]] = {
-        r'.*\.f90': FortranAnalyser,
-        r'.*\.F90': FortranPreProcessor,
-    }
-    _compile_map: Dict[str, Type[Command]] = {
-        r'.*\.f90': FortranCompiler,
-    }
+    _precompile_map: List[Tuple[str, Union[Type[Task], Type[Command]]]] = [
+        (r'.*\.f90', FortranAnalyser),
+        (r'.*\.F90', FortranPreProcessor),
+    ]
+    _compile_map: List[Tuple[str, Type[Command]]] = [
+        (r'.*\.f90', FortranCompiler),
+    ]
 
     def __init__(self,
                  workspace: Path,
@@ -223,9 +223,12 @@ class Fab(object):
             #       and pass this to the constructor for
             #       inclusion in the task's "products"
             compiler_class = None
-            for pattern in self._compile_map:
+            for pattern, classname in self._compile_map:
+                # Note we keep searching through the map
+                # even after a match is found; this means that
+                # later matches will override earlier ones
                 if match(pattern, str(unit.found_in)):
-                    compiler_class = self._compile_map[pattern]
+                    compiler_class = classname
                     break
 
             if compiler_class is None:

--- a/source/fab/builder.py
+++ b/source/fab/builder.py
@@ -229,7 +229,6 @@ class Fab(object):
                 # later matches will override earlier ones
                 if match(pattern, str(unit.found_in)):
                     compiler_class = classname
-                    break
 
             if compiler_class is None:
                 continue

--- a/source/fab/source_tree.py
+++ b/source/fab/source_tree.py
@@ -30,13 +30,13 @@ class TreeVisitor(ABC):
 
 class SourceVisitor(TreeVisitor):
     def __init__(self,
-                 source_map:
+                 path_map:
                      List[Tuple[str, Union[Type[Task], Type[Command]]]],
                  command_flags_map: Mapping[Type[Command], List[str]],
                  state: SqliteStateDatabase,
                  workspace: Path,
                  task_handler: Callable):
-        self._source_map = source_map
+        self._path_map = path_map
         self._command_flags_map = command_flags_map
         self._state = state
         self._workspace = workspace
@@ -46,7 +46,7 @@ class SourceVisitor(TreeVisitor):
         new_candidates: List[Path] = []
 
         task_class = None
-        for pattern, classname in self._source_map:
+        for pattern, classname in self._path_map:
             # Note we keep searching through the map
             # even after a match is found; this means that
             # later matches will override earlier ones

--- a/unit-tests/source_tree_test.py
+++ b/unit-tests/source_tree_test.py
@@ -9,10 +9,10 @@ from typing import Union, List, Dict, Type
 
 from fab.database import SqliteStateDatabase
 from fab.tasks import Analyser, Command, SingleFileCommand, Task
-from fab.source_tree import ExtensionVisitor, TreeDescent, TreeVisitor
+from fab.source_tree import SourceVisitor, TreeDescent, TreeVisitor
 
 
-class TestExtensionVisitor(object):
+class TestSourceVisitor(object):
     def test_analyser(self, tmp_path: Path):
         (tmp_path / 'test.foo').write_text("First file")
         (tmp_path / 'directory').mkdir()
@@ -27,14 +27,14 @@ class TestExtensionVisitor(object):
 
         db = SqliteStateDatabase(tmp_path)
         emap: Dict[str, Union[Type[Task], Type[Command]]] = {
-            '.foo': DummyTask
+            r'.*\.foo': DummyTask
         }
         fmap: Dict[Type[Command], List[str]] = {}
 
         def taskrunner(task):
             task.run()
 
-        test_unit = ExtensionVisitor(emap, fmap, db, tmp_path, taskrunner)
+        test_unit = SourceVisitor(emap, fmap, db, tmp_path, taskrunner)
         tracker.clear()
 
         test_unit.visit(tmp_path / 'test.foo')
@@ -64,14 +64,14 @@ class TestExtensionVisitor(object):
 
         db = SqliteStateDatabase(tmp_path)
         emap: Dict[str, Union[Type[Task], Type[Command]]] = {
-            '.bar': DummyCommand
+            r'.*\.bar': DummyCommand
         }
         fmap: Dict[Type[Command], List[str]] = {}
 
         def taskrunner(task):
             task.run()
 
-        test_unit = ExtensionVisitor(emap, fmap, db, tmp_path, taskrunner)
+        test_unit = SourceVisitor(emap, fmap, db, tmp_path, taskrunner)
         tracker.clear()
 
         test_unit.visit(tmp_path / 'test.bar')
@@ -92,14 +92,14 @@ class TestExtensionVisitor(object):
 
         db = SqliteStateDatabase(tmp_path)
         emap: Dict[str, Union[Type[Task], Type[Command]]] = {
-            '.expected': DummyAnalyser
+            r'.*\.expected': DummyAnalyser
         }
         fmap: Dict[Type[Command], List[str]] = {}
 
         def taskrunner(task):
             task.run()
 
-        test_unit = ExtensionVisitor(emap, fmap, db, tmp_path, taskrunner)
+        test_unit = SourceVisitor(emap, fmap, db, tmp_path, taskrunner)
         tracker.clear()
 
         test_unit.visit(tmp_path / 'test.what')
@@ -123,14 +123,14 @@ class TestExtensionVisitor(object):
 
         db = SqliteStateDatabase(tmp_path)
         emap: Dict[str, Union[Type[Task], Type[Command]]] = {
-            '.qux': WhatnowCommand,
+            r'.*\.qux': WhatnowCommand,
             }
         fmap: Dict[Type[Command], List[str]] = {}
 
         def taskrunner(task):
             task.run()
 
-        test_unit = ExtensionVisitor(emap, fmap, db, tmp_path, taskrunner)
+        test_unit = SourceVisitor(emap, fmap, db, tmp_path, taskrunner)
         with pytest.raises(TypeError):
             test_unit.visit(tmp_path / 'test.qux')
 

--- a/unit-tests/source_tree_test.py
+++ b/unit-tests/source_tree_test.py
@@ -5,11 +5,15 @@
 ##############################################################################
 from pathlib import Path
 import pytest  # type: ignore
-from typing import Union, List, Dict, Type, Tuple
+from typing import List, Dict, Type
 
 from fab.database import SqliteStateDatabase
-from fab.tasks import Analyser, Command, SingleFileCommand, Task
-from fab.source_tree import SourceVisitor, TreeDescent, TreeVisitor
+from fab.tasks import Analyser, Command, SingleFileCommand
+from fab.source_tree import \
+    SourceVisitor, \
+    TreeDescent, \
+    TreeVisitor, \
+    PathMap
 
 
 class TestSourceVisitor(object):
@@ -26,9 +30,9 @@ class TestSourceVisitor(object):
                 tracker.append(self._reader.filename)
 
         db = SqliteStateDatabase(tmp_path)
-        smap: List[Tuple[str, Union[Type[Task], Type[Command]]]] = [
+        smap = PathMap([
             (r'.*\.foo', DummyTask),
-        ]
+        ])
         fmap: Dict[Type[Command], List[str]] = {}
 
         def taskrunner(task):
@@ -63,9 +67,9 @@ class TestSourceVisitor(object):
                 return ['cp', str(self._filename), str(self.output[0])]
 
         db = SqliteStateDatabase(tmp_path)
-        smap: List[Tuple[str, Union[Type[Task], Type[Command]]]] = [
+        smap = PathMap([
             (r'.*\.bar', DummyCommand),
-        ]
+        ])
         fmap: Dict[Type[Command], List[str]] = {}
 
         def taskrunner(task):
@@ -91,9 +95,9 @@ class TestSourceVisitor(object):
                 tracker.append(self._reader.filename)
 
         db = SqliteStateDatabase(tmp_path)
-        smap: List[Tuple[str, Union[Type[Task], Type[Command]]]] = [
+        smap = PathMap([
             (r'.*\.expected', DummyAnalyser),
-        ]
+        ])
         fmap: Dict[Type[Command], List[str]] = {}
 
         def taskrunner(task):
@@ -122,9 +126,9 @@ class TestSourceVisitor(object):
                 return []
 
         db = SqliteStateDatabase(tmp_path)
-        smap: List[Tuple[str, Union[Type[Task], Type[Command]]]] = [
+        smap = PathMap([
             (r'.*\.qux', WhatnowCommand),
-        ]
+        ])
         fmap: Dict[Type[Command], List[str]] = {}
 
         def taskrunner(task):
@@ -153,10 +157,10 @@ class TestSourceVisitor(object):
                 trackerB.append(self._reader.filename)
 
         db = SqliteStateDatabase(tmp_path)
-        smap: List[Tuple[str, Union[Type[Task], Type[Command]]]] = [
+        smap = PathMap([
             (r'.*\.foo', DummyTaskA),
             (r'.*/directory/.*\.foo', DummyTaskB)
-        ]
+        ])
         fmap: Dict[Type[Command], List[str]] = {}
 
         def taskrunner(task):


### PR DESCRIPTION
As part of preparing to support the slightly more complicated workflow involved in the pre-compilation steps for C source and header files, this updates the extension visitor so that instead of doing a simple check on the extension of a file, it defines and matches a regex.  In this way it will be possible to have multiple steps using different Task classes on files with the same extension (but different paths) in a way that means we don't tie ourselves in knots inventing many bespoke intermediate extensions 