### PR TITLE
Phases

### DIFF
--- a/source/fab/builder.py
+++ b/source/fab/builder.py
@@ -102,10 +102,10 @@ class Fab(object):
 
     _phase_maps = [
         PathMap([
-            (r'.*\.f90', FortranAnalyser),
+            (r'.*\.F90', FortranPreProcessor),
         ]),
         PathMap([
-            (r'.*\.F90', FortranPreProcessor),
+            (r'.*\.f90', FortranAnalyser),
         ]),
     ]
 

--- a/source/fab/dumper.py
+++ b/source/fab/dumper.py
@@ -62,7 +62,7 @@ class Dump(object):
             print(f"  File   : {file_info.filename}", file=stream)
             # Where files are generated in the working directory
             # by third party tools, we cannot guarantee the hashes
-            if file_info.filename.match(f'{self._workspace}/*'):
+            if file_info.filename.match(f'{self._workspace}/phase*/*'):
                 print('    Hash : --hidden-- (generated file)')
             else:
                 print(f"    Hash : {file_info.adler32}", file=stream)

--- a/source/fab/source_tree.py
+++ b/source/fab/source_tree.py
@@ -63,7 +63,7 @@ class SourceVisitor(TreeVisitor):
         if task_class is None:
             return new_candidates
 
-        reader: TextReader = FileTextReader(candidate)
+        reader: TextReader = FileTextReader(candidate.resolve())
 
         if issubclass(task_class, Analyser):
             task: Task = task_class(reader, self._state)
@@ -80,6 +80,20 @@ class SourceVisitor(TreeVisitor):
 
         new_candidates.extend(task.products)
         return new_candidates
+
+
+class CoreLinker(TreeVisitor):
+    def __init__(self, core_dir: Path, extensions: List[str]):
+        self._core_dir = core_dir
+        self._extensions = extensions
+
+    def visit(self, candidate: Path):
+        if candidate.suffix in self._extensions:
+            link = self._core_dir / candidate.name
+            if link.exists():
+                link.unlink()
+            link.symlink_to(candidate.absolute())
+        return []
 
 
 class TreeDescent(object):

--- a/system-tests/FortranDependencies/expected.dump.txt
+++ b/system-tests/FortranDependencies/expected.dump.txt
@@ -1,27 +1,27 @@
 File View
-  File   : system-tests/FortranDependencies/bye_mod.f90
+  File   : {source}/bye_mod.f90
     Hash : 2054258567
-  File   : system-tests/FortranDependencies/constants_mod.f90
+  File   : {source}/constants_mod.f90
     Hash : 1014899572
-  File   : system-tests/FortranDependencies/first.f90
+  File   : {source}/first.f90
     Hash : 1577883012
-  File   : system-tests/FortranDependencies/greeting_mod.f90
+  File   : {source}/greeting_mod.f90
     Hash : 1789892039
-  File   : system-tests/FortranDependencies/two.f90
+  File   : {source}/two.f90
     Hash : 624596557
 Fortran View
   Program unit    : bye_mod
-    Found in      : system-tests/FortranDependencies/bye_mod.f90
+    Found in      : {source}/bye_mod.f90
     Prerequisites : constants_mod
   Program unit    : constants_mod
-    Found in      : system-tests/FortranDependencies/constants_mod.f90
+    Found in      : {source}/constants_mod.f90
     Prerequisites : 
   Program unit    : first
-    Found in      : system-tests/FortranDependencies/first.f90
+    Found in      : {source}/first.f90
     Prerequisites : constants_mod, greeting_mod
   Program unit    : greeting_mod
-    Found in      : system-tests/FortranDependencies/greeting_mod.f90
+    Found in      : {source}/greeting_mod.f90
     Prerequisites : constants_mod
   Program unit    : second
-    Found in      : system-tests/FortranDependencies/two.f90
+    Found in      : {source}/two.f90
     Prerequisites : bye_mod, constants_mod

--- a/system-tests/FortranDependencies/expected.fab.txt
+++ b/system-tests/FortranDependencies/expected.fab.txt
@@ -1,25 +1,25 @@
-system-tests/FortranDependencies/bye_mod.f90
+{source}/bye_mod.f90
     hash: 2054258567
-system-tests/FortranDependencies/constants_mod.f90
+{source}/constants_mod.f90
     hash: 1014899572
-system-tests/FortranDependencies/first.f90
+{source}/first.f90
     hash: 1577883012
-system-tests/FortranDependencies/greeting_mod.f90
+{source}/greeting_mod.f90
     hash: 1789892039
-system-tests/FortranDependencies/two.f90
+{source}/two.f90
     hash: 624596557
 bye_mod
-    found in: system-tests/FortranDependencies/bye_mod.f90
+    found in: {source}/bye_mod.f90
     depends on: ['constants_mod']
 constants_mod
-    found in: system-tests/FortranDependencies/constants_mod.f90
+    found in: {source}/constants_mod.f90
     depends on: []
 first
-    found in: system-tests/FortranDependencies/first.f90
+    found in: {source}/first.f90
     depends on: ['constants_mod', 'greeting_mod']
 greeting_mod
-    found in: system-tests/FortranDependencies/greeting_mod.f90
+    found in: {source}/greeting_mod.f90
     depends on: ['constants_mod']
 second
-    found in: system-tests/FortranDependencies/two.f90
+    found in: {source}/two.f90
     depends on: ['bye_mod', 'constants_mod']

--- a/system-tests/FortranPreProcess/expected.dump.go.txt
+++ b/system-tests/FortranPreProcess/expected.dump.go.txt
@@ -1,24 +1,24 @@
 File View
-  File   : system-tests/FortranPreProcess/clash.F90
+  File   : {source}/clash.F90
     Hash : 1656734134
-  File   : system-tests/FortranPreProcess/constants_mod.f90
+  File   : {source}/constants_mod.f90
     Hash : 1014899572
-  File   : system-tests/FortranPreProcess/go_now_mod.f90
+  File   : {source}/go_now_mod.f90
     Hash : 374511745
-  File   : system-tests/FortranPreProcess/stay_mod.f90
+  File   : {source}/stay_mod.f90
     Hash : 3960444120
-  File   : system-tests/FortranPreProcess/working/clash.f90
+  File   : {working}/phase_0/clash.f90
     Hash : --hidden-- (generated file)
 Fortran View
   Program unit    : constants_mod
-    Found in      : system-tests/FortranPreProcess/constants_mod.f90
+    Found in      : {source}/constants_mod.f90
     Prerequisites : 
   Program unit    : go_now_mod
-    Found in      : system-tests/FortranPreProcess/go_now_mod.f90
+    Found in      : {source}/go_now_mod.f90
     Prerequisites : constants_mod
   Program unit    : stay_mod
-    Found in      : system-tests/FortranPreProcess/stay_mod.f90
+    Found in      : {source}/stay_mod.f90
     Prerequisites : constants_mod
   Program unit    : stay_or_go_now
-    Found in      : system-tests/FortranPreProcess/working/clash.f90
+    Found in      : {working}/phase_0/clash.f90
     Prerequisites : constants_mod, go_now_mod

--- a/system-tests/FortranPreProcess/expected.dump.stay.txt
+++ b/system-tests/FortranPreProcess/expected.dump.stay.txt
@@ -1,24 +1,24 @@
 File View
-  File   : system-tests/FortranPreProcess/clash.F90
+  File   : {source}/clash.F90
     Hash : 1656734134
-  File   : system-tests/FortranPreProcess/constants_mod.f90
+  File   : {source}/constants_mod.f90
     Hash : 1014899572
-  File   : system-tests/FortranPreProcess/go_now_mod.f90
+  File   : {source}/go_now_mod.f90
     Hash : 374511745
-  File   : system-tests/FortranPreProcess/stay_mod.f90
+  File   : {source}/stay_mod.f90
     Hash : 3960444120
-  File   : system-tests/FortranPreProcess/working/clash.f90
+  File   : {working}/phase_0/clash.f90
     Hash : --hidden-- (generated file)
 Fortran View
   Program unit    : constants_mod
-    Found in      : system-tests/FortranPreProcess/constants_mod.f90
+    Found in      : {source}/constants_mod.f90
     Prerequisites : 
   Program unit    : go_now_mod
-    Found in      : system-tests/FortranPreProcess/go_now_mod.f90
+    Found in      : {source}/go_now_mod.f90
     Prerequisites : constants_mod
   Program unit    : stay_mod
-    Found in      : system-tests/FortranPreProcess/stay_mod.f90
+    Found in      : {source}/stay_mod.f90
     Prerequisites : constants_mod
   Program unit    : stay_or_go_now
-    Found in      : system-tests/FortranPreProcess/working/clash.f90
+    Found in      : {working}/phase_0/clash.f90
     Prerequisites : constants_mod, stay_mod

--- a/system-tests/FortranPreProcess/expected.fab.go.txt
+++ b/system-tests/FortranPreProcess/expected.fab.go.txt
@@ -1,22 +1,22 @@
-system-tests/FortranPreProcess/clash.F90
+{source}/clash.F90
     hash: 1656734134
-system-tests/FortranPreProcess/constants_mod.f90
+{source}/constants_mod.f90
     hash: 1014899572
-system-tests/FortranPreProcess/go_now_mod.f90
+{source}/go_now_mod.f90
     hash: 374511745
-system-tests/FortranPreProcess/stay_mod.f90
+{source}/stay_mod.f90
     hash: 3960444120
-system-tests/FortranPreProcess/working/clash.f90
+{working}/phase_0/clash.f90
     hash: --hidden-- (generated file)
 constants_mod
-    found in: system-tests/FortranPreProcess/constants_mod.f90
+    found in: {source}/constants_mod.f90
     depends on: []
 go_now_mod
-    found in: system-tests/FortranPreProcess/go_now_mod.f90
+    found in: {source}/go_now_mod.f90
     depends on: ['constants_mod']
 stay_mod
-    found in: system-tests/FortranPreProcess/stay_mod.f90
+    found in: {source}/stay_mod.f90
     depends on: ['constants_mod']
 stay_or_go_now
-    found in: system-tests/FortranPreProcess/working/clash.f90
+    found in: {working}/phase_0/clash.f90
     depends on: ['constants_mod', 'go_now_mod']

--- a/system-tests/FortranPreProcess/expected.fab.stay.txt
+++ b/system-tests/FortranPreProcess/expected.fab.stay.txt
@@ -1,22 +1,22 @@
-system-tests/FortranPreProcess/clash.F90
+{source}/clash.F90
     hash: 1656734134
-system-tests/FortranPreProcess/constants_mod.f90
+{source}/constants_mod.f90
     hash: 1014899572
-system-tests/FortranPreProcess/go_now_mod.f90
+{source}/go_now_mod.f90
     hash: 374511745
-system-tests/FortranPreProcess/stay_mod.f90
+{source}/stay_mod.f90
     hash: 3960444120
-system-tests/FortranPreProcess/working/clash.f90
+{working}/phase_0/clash.f90
     hash: --hidden-- (generated file)
 constants_mod
-    found in: system-tests/FortranPreProcess/constants_mod.f90
+    found in: {source}/constants_mod.f90
     depends on: []
 go_now_mod
-    found in: system-tests/FortranPreProcess/go_now_mod.f90
+    found in: {source}/go_now_mod.f90
     depends on: ['constants_mod']
 stay_mod
-    found in: system-tests/FortranPreProcess/stay_mod.f90
+    found in: {source}/stay_mod.f90
     depends on: ['constants_mod']
 stay_or_go_now
-    found in: system-tests/FortranPreProcess/working/clash.f90
+    found in: {working}/phase_0/clash.f90
     depends on: ['constants_mod', 'stay_mod']

--- a/system-tests/MinimalFortran/expected.dump.txt
+++ b/system-tests/MinimalFortran/expected.dump.txt
@@ -1,7 +1,7 @@
 File View
-  File   : system-tests/MinimalFortran/program.f90
+  File   : {source}/program.f90
     Hash : 779717536
 Fortran View
   Program unit    : test
-    Found in      : system-tests/MinimalFortran/program.f90
+    Found in      : {source}/program.f90
     Prerequisites : 

--- a/system-tests/MinimalFortran/expected.fab.txt
+++ b/system-tests/MinimalFortran/expected.fab.txt
@@ -1,5 +1,5 @@
-system-tests/MinimalFortran/program.f90
+{source}/program.f90
     hash: 779717536
 test
-    found in: system-tests/MinimalFortran/program.f90
+    found in: {source}/program.f90
     depends on: []

--- a/system-tests/test.py
+++ b/system-tests/test.py
@@ -342,6 +342,14 @@ class CompareConsoleWithFile(CheckTask):
         path = task.test_parameters.test_directory / leaf_name
         self._expected = path.read_text().splitlines(keepends=True)
 
+        # Make substitutions for source / working directory in output
+        # since absolute paths are platform dependent
+        test_dir = task.test_parameters.test_directory.absolute()
+        work_dir = task.test_parameters.work_directory.absolute()
+        for iline, line in enumerate(self._expected):
+            self._expected[iline] = line.format(
+                source=str(test_dir), working=str(work_dir))
+
     def check(self):
         self.assert_true(self.task.return_code == 0)
         lines = self.task.standard_out.splitlines(keepends=True)


### PR DESCRIPTION
This implements the idea of having multiple "phases" to (for now) the steps leading up to the compilation + linking (so all the preprocessing and analysis type tasks).  It allows several of our `extension_map` dictionaries to be provided - each of these represents a "phase", with a queue synchronisation inbetween each of these (which allows us to mandate types of `Task` which must complete across the entire source tree before the next phase can begin - similar to the sync between the old preprocess/analysis steps and the compilation itself)

In order to manage the output files a new system is implemented in the `working` directory - a `core` directory contains sym links to the "current state" of the build (initially this is setup to link to the original source files).  Each `phase` points at this directory for its input, but places any produced files into its own `phase_?` directory (incrementing each phase).  At the end of each phase the files in the `core` directory are updated to point to any new files in the (just completed) `phase_?` directory.  In this way `Task`s can produce files with identical extensions as output, and it should hopefully lend itself nicely to debugging and implementing incremental builds later.

Closes #75 