### PR TITLE
Sometimes the Subversion server test will fail

### DIFF
--- a/unit-tests/repository_test.py
+++ b/unit-tests/repository_test.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from subprocess import run, Popen
 import shutil
 import signal
+import time
 from typing import List, Tuple
 
 from pytest import fixture, mark, raises  # type: ignore
@@ -87,6 +88,7 @@ class TestSubversion:
             except FabException as ex:
                 if range == 0:
                     raise ex
+                time.sleep(1.0)
             else:
                 break
         _tree_compare(repo[1], tmp_path)

--- a/unit-tests/repository_test.py
+++ b/unit-tests/repository_test.py
@@ -81,7 +81,7 @@ class TestSubversion:
         # TODO: Is there a better solution such that we don't try to connect
         #       until the socket is open?
         #
-        for retry in range(3, 0 ,-1):
+        for retry in range(3, 0, -1):
             try:
                 test_unit.extract(tmp_path)
             except FabException as ex:

--- a/unit-tests/repository_test.py
+++ b/unit-tests/repository_test.py
@@ -74,7 +74,21 @@ class TestSubversion:
         process = Popen(command)
 
         test_unit = SubversionRepo('svn://localhost/trunk')
-        test_unit.extract(tmp_path)
+        #
+        # It seems there can be a delay between the server starting and the
+        # listen socket opening. Thus we have a number of retries.
+        #
+        # TODO: Is there a better solution such that we don't try to connect
+        #       until the socket is open?
+        #
+        for retry in range(3, 0 ,-1):
+            try:
+                test_unit.extract(tmp_path)
+            except FabException as ex:
+                if range == 0:
+                    raise ex
+            else:
+                break
         _tree_compare(repo[1], tmp_path)
         assert not (tmp_path / '.svn').exists()
 


### PR DESCRIPTION
This seems to be down to latency in the server opening its network connection. This fix adds a crude retry loop. It runs the risk of missing legitimate failures but should prevent spurious failures.