### PR TITLE
Retire systest in favour of pytest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,4 +45,4 @@ jobs:
     - name: Test with systest
       run: |
         pip install .[system-test]
-        python system-tests/test.py
+        python -m pytest --cov=sci-fab system-tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,8 +41,8 @@ jobs:
     - name: Unit tests with Pytest
       run: |
         pip install .[unit-test]
-        python -m pytest --cov=sci-fab unit-tests
+        python -m pytest --cov=fab unit-tests
     - name: System tests with Pytest
       run: |
         pip install .[system-test]
-        python -m pytest --cov=sci-fab system-tests
+        python -m pytest system-tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,11 +38,11 @@ jobs:
       run: |
         pip install -e .[dev]
         flake8 . --count --show-source --statistics
-    - name: Test with pytest
+    - name: Unit tests with Pytest
       run: |
         pip install .[unit-test]
         python -m pytest --cov=sci-fab unit-tests
-    - name: Test with systest
+    - name: System tests with Pytest
       run: |
         pip install .[system-test]
         python -m pytest --cov=sci-fab system-tests

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,6 @@ setuptools.setup(
     extras_require={
         'dev': ['flake8', 'mypy'],
         'unit-test': ['pytest', 'pytest-cov', 'pytest-mock'],
-        'system-test': ['systest >= 5.5.0']
+        'system-test': ['pytest', 'pytest-cov', 'pytest-mock']
     }
 )

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,6 @@ setuptools.setup(
     extras_require={
         'dev': ['flake8', 'mypy'],
         'unit-test': ['pytest', 'pytest-cov', 'pytest-mock'],
-        'system-test': ['pytest', 'pytest-cov', 'pytest-mock']
+        'system-test': ['pytest']
     }
 )

--- a/system-tests/CUserHeader_test.py
+++ b/system-tests/CUserHeader_test.py
@@ -6,7 +6,7 @@
 from pathlib import Path
 from common import CompareConsoleWithFile, RunFab, RunExec, RunDump
 
-TEST_PATH = Path('system-tests/CUserHeader')
+TEST_PATH = Path('system-tests') / Path(__file__).name.split('_test.py')[0]
 
 
 def test_fab():

--- a/system-tests/CUserHeader_test.py
+++ b/system-tests/CUserHeader_test.py
@@ -1,0 +1,27 @@
+##############################################################################
+# (c) Crown copyright Met Office. All rights reserved.
+# For further details please refer to the file COPYRIGHT
+# which you should have received as part of this distribution
+##############################################################################
+from pathlib import Path
+from common import CompareConsoleWithFile, RunFab, RunExec, RunDump
+
+TEST_PATH = Path('system-tests/CUserHeader')
+
+
+def test_fab():
+    command = RunFab(TEST_PATH, 'main')
+    comparison = CompareConsoleWithFile(command)
+    comparison.run()
+
+
+def test_exec():
+    command = RunExec(TEST_PATH)
+    comparison = CompareConsoleWithFile(command)
+    comparison.run()
+
+
+def test_dump():
+    command = RunDump(TEST_PATH)
+    comparison = CompareConsoleWithFile(command)
+    comparison.run()

--- a/system-tests/FortranDependencies_test.py
+++ b/system-tests/FortranDependencies_test.py
@@ -6,7 +6,7 @@
 from pathlib import Path
 from common import CompareConsoleWithFile, RunFab, RunExec, RunDump
 
-TEST_PATH = Path('system-tests/FortranDependencies')
+TEST_PATH = Path('system-tests') / Path(__file__).name.split('_test.py')[0]
 
 
 def test_fab():

--- a/system-tests/FortranDependencies_test.py
+++ b/system-tests/FortranDependencies_test.py
@@ -1,0 +1,27 @@
+##############################################################################
+# (c) Crown copyright Met Office. All rights reserved.
+# For further details please refer to the file COPYRIGHT
+# which you should have received as part of this distribution
+##############################################################################
+from pathlib import Path
+from common import CompareConsoleWithFile, RunFab, RunExec, RunDump
+
+TEST_PATH = Path('system-tests/FortranDependencies')
+
+
+def test_fab():
+    command = RunFab(TEST_PATH, 'first')
+    comparison = CompareConsoleWithFile(command)
+    comparison.run()
+
+
+def test_exec():
+    command = RunExec(TEST_PATH)
+    comparison = CompareConsoleWithFile(command)
+    comparison.run()
+
+
+def test_dump():
+    command = RunDump(TEST_PATH)
+    comparison = CompareConsoleWithFile(command)
+    comparison.run()

--- a/system-tests/FortranPreProcess_test.py
+++ b/system-tests/FortranPreProcess_test.py
@@ -6,7 +6,7 @@
 from pathlib import Path
 from common import CompareConsoleWithFile, RunFab, RunExec, RunDump
 
-TEST_PATH = Path('system-tests/FortranPreProcess')
+TEST_PATH = Path('system-tests') / Path(__file__).name.split('_test.py')[0]
 
 
 def test_fab_stay():

--- a/system-tests/FortranPreProcess_test.py
+++ b/system-tests/FortranPreProcess_test.py
@@ -1,0 +1,62 @@
+##############################################################################
+# (c) Crown copyright Met Office. All rights reserved.
+# For further details please refer to the file COPYRIGHT
+# which you should have received as part of this distribution
+##############################################################################
+from pathlib import Path
+from common import CompareConsoleWithFile, RunFab, RunExec, RunDump
+
+TEST_PATH = Path('system-tests/FortranPreProcess')
+
+
+def test_fab_stay():
+    command = RunFab(
+        TEST_PATH,
+        'stay_or_go_now',
+        fpp_flags='-DSHOULD_I_STAY=yes')
+    comparison = CompareConsoleWithFile(
+        command,
+        expectation_suffix='stay')
+    comparison.run()
+
+
+def test_exec_stay():
+    command = RunExec(TEST_PATH)
+    comparison = CompareConsoleWithFile(
+        command,
+        expectation_suffix='stay')
+    comparison.run()
+
+
+def test_dump_stay():
+    command = RunDump(TEST_PATH)
+    comparison = CompareConsoleWithFile(
+        command,
+        expectation_suffix='stay')
+    comparison.run()
+
+
+def test_fab_go():
+    command = RunFab(
+        TEST_PATH,
+        'stay_or_go_now')
+    comparison = CompareConsoleWithFile(
+        command,
+        expectation_suffix='go')
+    comparison.run()
+
+
+def test_exec_go():
+    command = RunExec(TEST_PATH)
+    comparison = CompareConsoleWithFile(
+        command,
+        expectation_suffix='go')
+    comparison.run()
+
+
+def test_dump_go():
+    command = RunDump(TEST_PATH)
+    comparison = CompareConsoleWithFile(
+        command,
+        expectation_suffix='go')
+    comparison.run()

--- a/system-tests/GitRepository_test.py
+++ b/system-tests/GitRepository_test.py
@@ -6,7 +6,7 @@
 from pathlib import Path
 from common import CompareFileTrees, RunGrab
 
-TEST_PATH = Path('system-tests/GitRepository')
+TEST_PATH = Path('system-tests') / Path(__file__).name.split('_test.py')[0]
 
 
 def test_grab():

--- a/system-tests/GitRepository_test.py
+++ b/system-tests/GitRepository_test.py
@@ -1,0 +1,17 @@
+##############################################################################
+# (c) Crown copyright Met Office. All rights reserved.
+# For further details please refer to the file COPYRIGHT
+# which you should have received as part of this distribution
+##############################################################################
+from pathlib import Path
+from common import CompareFileTrees, RunGrab
+
+TEST_PATH = Path('system-tests/GitRepository')
+
+
+def test_grab():
+    # TODO: I can't test with the Git protocol as for some reason the
+    #       Git daemon isn't installed.
+    command = RunGrab(TEST_PATH, 'git', 'file')
+    comparison = CompareFileTrees(command)
+    comparison.run()

--- a/system-tests/MinimalC_test.py
+++ b/system-tests/MinimalC_test.py
@@ -6,7 +6,7 @@
 from pathlib import Path
 from common import CompareConsoleWithFile, RunFab, RunExec, RunDump
 
-TEST_PATH = Path('system-tests/MinimalC')
+TEST_PATH = Path('system-tests') / Path(__file__).name.split('_test.py')[0]
 
 
 def test_fab():

--- a/system-tests/MinimalC_test.py
+++ b/system-tests/MinimalC_test.py
@@ -1,0 +1,27 @@
+##############################################################################
+# (c) Crown copyright Met Office. All rights reserved.
+# For further details please refer to the file COPYRIGHT
+# which you should have received as part of this distribution
+##############################################################################
+from pathlib import Path
+from common import CompareConsoleWithFile, RunFab, RunExec, RunDump
+
+TEST_PATH = Path('system-tests/MinimalC')
+
+
+def test_fab():
+    command = RunFab(TEST_PATH, 'main')
+    comparison = CompareConsoleWithFile(command)
+    comparison.run()
+
+
+def test_exec():
+    command = RunExec(TEST_PATH)
+    comparison = CompareConsoleWithFile(command)
+    comparison.run()
+
+
+def test_dump():
+    command = RunDump(TEST_PATH)
+    comparison = CompareConsoleWithFile(command)
+    comparison.run()

--- a/system-tests/MinimalFortran_test.py
+++ b/system-tests/MinimalFortran_test.py
@@ -6,7 +6,7 @@
 from pathlib import Path
 from common import CompareConsoleWithFile, RunFab, RunExec, RunDump
 
-TEST_PATH = Path('system-tests/MinimalFortran')
+TEST_PATH = Path('system-tests') / Path(__file__).name.split('_test.py')[0]
 
 
 def test_fab():

--- a/system-tests/MinimalFortran_test.py
+++ b/system-tests/MinimalFortran_test.py
@@ -1,0 +1,27 @@
+##############################################################################
+# (c) Crown copyright Met Office. All rights reserved.
+# For further details please refer to the file COPYRIGHT
+# which you should have received as part of this distribution
+##############################################################################
+from pathlib import Path
+from common import CompareConsoleWithFile, RunFab, RunExec, RunDump
+
+TEST_PATH = Path('system-tests/MinimalFortran')
+
+
+def test_fab():
+    command = RunFab(TEST_PATH, 'test')
+    comparison = CompareConsoleWithFile(command)
+    comparison.run()
+
+
+def test_exec():
+    command = RunExec(TEST_PATH)
+    comparison = CompareConsoleWithFile(command)
+    comparison.run()
+
+
+def test_dump():
+    command = RunDump(TEST_PATH)
+    comparison = CompareConsoleWithFile(command)
+    comparison.run()

--- a/system-tests/SubversionRepository_test.py
+++ b/system-tests/SubversionRepository_test.py
@@ -6,7 +6,7 @@
 from pathlib import Path
 from common import CompareFileTrees, RunGrab
 
-TEST_PATH = Path('system-tests/SubversionRepository')
+TEST_PATH = Path('system-tests') / Path(__file__).name.split('_test.py')[0]
 
 
 def test_grab_file():

--- a/system-tests/SubversionRepository_test.py
+++ b/system-tests/SubversionRepository_test.py
@@ -1,0 +1,21 @@
+##############################################################################
+# (c) Crown copyright Met Office. All rights reserved.
+# For further details please refer to the file COPYRIGHT
+# which you should have received as part of this distribution
+##############################################################################
+from pathlib import Path
+from common import CompareFileTrees, RunGrab
+
+TEST_PATH = Path('system-tests/SubversionRepository')
+
+
+def test_grab_file():
+    command = RunGrab(TEST_PATH, 'svn', 'file')
+    comparison = CompareFileTrees(command)
+    comparison.run()
+
+
+def test_grab_svn():
+    command = RunGrab(TEST_PATH, 'svn', 'svn')
+    comparison = CompareFileTrees(command)
+    comparison.run()

--- a/system-tests/common.py
+++ b/system-tests/common.py
@@ -309,7 +309,7 @@ class RunGrab(EnterPython):
             shutil.rmtree(self._repo_path)
 
 
-class CheckTask(ABC, metaclass=ABCMeta):
+class CheckTask(ABC):
     """
     Abstract parent of all checking test cases.
     """

--- a/system-tests/common.py
+++ b/system-tests/common.py
@@ -309,7 +309,7 @@ class RunGrab(EnterPython):
             shutil.rmtree(self._repo_path)
 
 
-class CheckTask(object, metaclass=ABCMeta):
+class CheckTask(ABC, metaclass=ABCMeta):
     """
     Abstract parent of all checking test cases.
     """
@@ -341,9 +341,10 @@ class CheckTask(object, metaclass=ABCMeta):
 class CompareConsoleWithFile(CheckTask):
     """
     Checks console output against expected result.
+
+    The expected result is held in a file "expected.<tag>[.<suffix>].txt.
+    Where "tag" comes from the task and "suffix" is specified.
     """
-    # The expected result is held in a file "expected.<tag>[.<suffix>].txt.
-    # Where "tag" comes from the task and "suffix" is specified.
     def __init__(self, task: RunCommand, expectation_suffix=None):
         super().__init__(task, name=task.description())
         leaf_name = f'expected.{task.test_parameters.tag}'
@@ -362,9 +363,10 @@ class CompareConsoleWithFile(CheckTask):
 class CompareFileTrees(CheckTask):
     """
     Checks filetree against expected result.
+
+    The test tree is the tasks working directory and the expected result
+    is in "expected".
     """
-    # The test tree is the tasks working directory and the expected result
-    # is in "expected".
     def __init__(self, task: RunCommand):
         super().__init__(task, name=task.description())
         self._expected = task.test_parameters.test_directory / 'expected'


### PR DESCRIPTION
We have been discussing and thinking for a while that we might want to drop `systest` - here we replace it in favour of using `pytest` to run both Unit and System testing.  Unsure if it's quite ready - this is a pretty light reworking just to prove that it runs; I suspect with a little more thought there may be a nicer design for it.  But it opens the discussion on how it should look at least