### PR TITLE
Allow debugging level to be specified and add more logging

### DIFF
--- a/source/fab/builder.py
+++ b/source/fab/builder.py
@@ -62,8 +62,9 @@ def entry() -> None:
     parser.add_argument('-V', '--version', action='version',
                         version=fab.__version__,
                         help='Print version identifier and exit')
-    parser.add_argument('-v', '--verbose', action='store_true',
-                        help='Produce a running commentary on progress')
+    parser.add_argument('-v', '--verbose', action='count', default=0,
+                        help='Increase verbosity (may be specified once '
+                             'for moderate and twice for debug verbosity)')
     parser.add_argument('-w', '--workspace', metavar='PATH', type=Path,
                         default=Path.cwd() / 'working',
                         help='Directory for working files.')
@@ -77,10 +78,9 @@ def entry() -> None:
                         help='The path of the configuration file')
     arguments = parser.parse_args()
 
-    if arguments.verbose:
-        logger.setLevel(logging.INFO)
-    else:
-        logger.setLevel(logging.WARNING)
+    verbosity_levels = [logging.WARNING, logging.INFO, logging.DEBUG]
+    verbosity = min(arguments.verbose, 2)
+    logger.setLevel(verbosity_levels[verbosity])
 
     config = configparser.ConfigParser(allow_no_value=True)
     configfile = arguments.conf_file

--- a/source/fab/dumper.py
+++ b/source/fab/dumper.py
@@ -35,17 +35,17 @@ def entry() -> None:
     parser.add_argument('-V', '--version', action='version',
                         version=fab.__version__,
                         help='Print version identifier and exit')
-    parser.add_argument('-v', '--verbose', action='store_true',
-                        help='Produce a running commentary on progress')
+    parser.add_argument('-v', '--verbose', action='count', default=0,
+                        help='Increase verbosity (may be specified once '
+                             'for moderate and twice for debug verbosity)')
     parser.add_argument('-w', '--workspace', metavar='PATH', type=Path,
                         default=Path.cwd() / 'working',
                         help='Directory for working files.')
     arguments = parser.parse_args()
 
-    if arguments.verbose:
-        logger.setLevel(logging.INFO)
-    else:
-        logger.setLevel(logging.WARNING)
+    verbosity_levels = [logging.WARNING, logging.INFO, logging.DEBUG]
+    verbosity = min(arguments.verbose, 2)
+    logger.setLevel(verbosity_levels[verbosity])
 
     application = Dump(arguments.workspace)
     application.run()

--- a/source/fab/grabber.py
+++ b/source/fab/grabber.py
@@ -34,8 +34,9 @@ def entry() -> None:
     parser.add_argument('-V', '--version', action='version',
                         version=fab.__version__,
                         help="Print version identifier and exit.")
-    parser.add_argument('-v', '--verbose', action='store_true',
-                        help="Produce a running commentary on progress.")
+    parser.add_argument('-v', '--verbose', action='count', default=0,
+                        help='Increase verbosity (may be specified once '
+                             'for moderate and twice for debug verbosity)')
     parser.add_argument('destination', metavar='PATH', type=Path,
                         default=Path.cwd() / 'source',
                         help="Source directory to create.")
@@ -44,10 +45,9 @@ def entry() -> None:
 
     arguments = parser.parse_args()
 
-    if arguments.verbose:
-        logger.setLevel(logging.INFO)
-    else:
-        logger.setLevel(logging.WARNING)
+    verbosity_levels = [logging.WARNING, logging.INFO, logging.DEBUG]
+    verbosity = min(arguments.verbose, 2)
+    logger.setLevel(verbosity_levels[verbosity])
 
     application = Grab(arguments.destination)
 

--- a/source/fab/tasks/fortran.py
+++ b/source/fab/tasks/fortran.py
@@ -382,6 +382,7 @@ class FortranAnalyser(Task):
 
         state = FortranWorkingState(self.database)
         state.remove_fortran_file(reader.filename)
+        logger.debug('Analysing: %s', reader.filename)
 
         normalised_source = FortranNormaliser(reader)
         scope: List[Tuple[str, str]] = []
@@ -497,6 +498,7 @@ class FortranPreProcessor(Task):
         self._workspace = workspace
 
     def run(self, artifacts: List[Artifact]) -> List[Artifact]:
+        logger = logging.getLogger(__name__)
 
         if len(artifacts) == 1:
             artifact = artifacts[0]
@@ -513,6 +515,7 @@ class FortranPreProcessor(Task):
                        artifact.location.with_suffix('.f90').name)
         command.append(str(output_file))
 
+        logger.debug('Running command: ' + ' '.join(command))
         subprocess.run(command, check=True)
 
         return [Artifact(output_file,
@@ -531,6 +534,7 @@ class FortranCompiler(Task):
         self._workspace = workspace
 
     def run(self, artifacts: List[Artifact]) -> List[Artifact]:
+        logger = logging.getLogger(__name__)
 
         if len(artifacts) == 1:
             artifact = artifacts[0]
@@ -547,6 +551,7 @@ class FortranCompiler(Task):
                        artifact.location.with_suffix('.o').name)
         command.extend(['-o', str(output_file)])
 
+        logger.debug('Running command: ' + ' '.join(command))
         subprocess.run(command, check=True)
 
         object_artifact = Artifact(output_file,


### PR DESCRIPTION
We have some existing debugging calls to the logger (in `fab.tasks.fortran.py`) but presently no way of specifying that logging level.  On the topic of logging also it would be helpful for other developments if there were slightly more logging on the other tasks so let's add a bit more to the debug level now that we can select it

A few thoughts I might appreciate the reviewer's input on:

 * I've copied what the `fortran` analyser does in the debug logging where it prints every line being "considered", only in the case of the `c` analyser it is iterating over `libclang` "node" objects - since this includes everything added by the preprocessor it ends up being a lot of spammy output.  I could restrict this so that it only prints interesting nodes to cut down on this (if we don't think that will lose too much helpfulness)
 * I contemplated moving the `getLogger` calls up to the module level, but hesitated in the end as I wasn't sure whether it was a good idea or not, but this does mean that they are duplicated a bit where files have multiple tasks
 * I updated the verbosity argument in all interfaces that had it despite it only really being utilised by the main `builder` one - figured it was sensible to be consistent, but maybe it's unnecessary?