### PR TITLE
Show procesing error message

### DIFF
--- a/source/fab/builder.py
+++ b/source/fab/builder.py
@@ -72,6 +72,7 @@ def entry() -> None:
                         choices=range(2, multiprocessing.cpu_count()),
                         help='Provide number of processors available for use,'
                              'default is 2 if not set.')
+    parser.add_argument('--stop-on-error', default=True)
     parser.add_argument('source', type=Path,
                         help='The path of the source tree to build')
     parser.add_argument('conf_file', type=Path, default='config.ini',
@@ -98,7 +99,8 @@ def entry() -> None:
                       flags['fpp-flags'],
                       flags['fc-flags'],
                       flags['ld-flags'],
-                      arguments.nprocs)
+                      arguments.nprocs,
+                      arguments.stop_on_error)
     application.run(arguments.source)
 
 
@@ -110,7 +112,8 @@ class Fab(object):
                  fpp_flags: str,
                  fc_flags: str,
                  ld_flags: str,
-                 n_procs: int):
+                 n_procs: int,
+                 stop_on_error: bool=True):
 
         self._workspace = workspace
         if not workspace.exists():
@@ -177,7 +180,7 @@ class Fab(object):
                         target,
                         path_maps,
                         task_map)
-        self._queue = QueueManager(n_procs - 1, engine)
+        self._queue = QueueManager(n_procs - 1, engine, stop_on_error)
 
     def _extend_queue(self, artifact: Artifact) -> None:
         self._queue.add_to_queue(artifact)

--- a/source/fab/builder.py
+++ b/source/fab/builder.py
@@ -72,7 +72,7 @@ def entry() -> None:
                         choices=range(2, multiprocessing.cpu_count()),
                         help='Provide number of processors available for use,'
                              'default is 2 if not set.')
-    parser.add_argument('--stop-on-error', default=True)
+    parser.add_argument('--stop-on-error', default=True, action="store_true")
     parser.add_argument('source', type=Path,
                         help='The path of the source tree to build')
     parser.add_argument('conf_file', type=Path, default='config.ini',

--- a/source/fab/builder.py
+++ b/source/fab/builder.py
@@ -72,7 +72,7 @@ def entry() -> None:
                         choices=range(2, multiprocessing.cpu_count()),
                         help='Provide number of processors available for use,'
                              'default is 2 if not set.')
-    parser.add_argument('--stop-on-error', default=True, action="store_true")
+    parser.add_argument('--stop-on-error', action="store_true")
     parser.add_argument('source', type=Path,
                         help='The path of the source tree to build')
     parser.add_argument('conf_file', type=Path, default='config.ini',

--- a/source/fab/builder.py
+++ b/source/fab/builder.py
@@ -72,7 +72,6 @@ def entry() -> None:
                         choices=range(2, multiprocessing.cpu_count()),
                         help='Provide number of processors available for use,'
                              'default is 2 if not set.')
-    parser.add_argument('--stop-on-error', action="store_true")
     parser.add_argument('source', type=Path,
                         help='The path of the source tree to build')
     parser.add_argument('conf_file', type=Path, default='config.ini',
@@ -99,8 +98,7 @@ def entry() -> None:
                       flags['fpp-flags'],
                       flags['fc-flags'],
                       flags['ld-flags'],
-                      arguments.nprocs,
-                      arguments.stop_on_error)
+                      arguments.nprocs)
     application.run(arguments.source)
 
 

--- a/source/fab/builder.py
+++ b/source/fab/builder.py
@@ -113,7 +113,7 @@ class Fab(object):
                  fc_flags: str,
                  ld_flags: str,
                  n_procs: int,
-                 stop_on_error: bool=True):
+                 stop_on_error: bool = True):
 
         self._workspace = workspace
         if not workspace.exists():

--- a/source/fab/queue.py
+++ b/source/fab/queue.py
@@ -33,15 +33,11 @@ def _worker(queue: JoinableQueue,
             lock: LockT,
             stopswitch: EventT):
 
-    logger = logging.getLogger(__name__)
-
     while not stopswitch.is_set():
         try:
             artifact = queue.get(block=True, timeout=0.5)
         except QueueEmpty:
             continue
-
-        logger.info(artifact)
 
         try:
             new_artifacts = engine.process(artifact,
@@ -55,8 +51,8 @@ def _worker(queue: JoinableQueue,
             print("ERROR processing", artifact)
             traceback.print_exc()
             # todo: sys.exit does not stop the entire program, it just stops the worker process.
-            #       I think this is because we're using the anti pattern "Joining processes that use queues",
-            #       described here:  https://docs.python.org/3/library/multiprocessing.html#all-start-methods
+            #       See "Joining processes that use queues" here:
+            #       https://docs.python.org/3/library/multiprocessing.html#all-start-methods
             print("Please exit with ctrl-c")
             sys.exit(1)
         finally:

--- a/source/fab/queue.py
+++ b/source/fab/queue.py
@@ -30,7 +30,7 @@ def _worker(queue: JoinableQueue,
             objects: List[Artifact],
             lock: LockT,
             stopswitch: EventT,
-            stop_on_error: bool=True):
+            stop_on_error: bool = True):
 
     logger = logging.getLogger(__file__)
 
@@ -58,7 +58,8 @@ def _worker(queue: JoinableQueue,
 
 
 class QueueManager(object):
-    def __init__(self, n_workers: int, engine: Engine, stop_on_error: bool=True):
+    def __init__(self, n_workers: int, engine: Engine,
+                 stop_on_error: bool = True):
         self._queue: Queue = JoinableQueue()
         self._n_workers = n_workers
         self._workers: List[int] = []

--- a/source/fab/queue.py
+++ b/source/fab/queue.py
@@ -49,7 +49,7 @@ def _worker(queue: JoinableQueue,
             for new_artifact in new_artifacts:
                 queue.put(new_artifact)
         except TaskException as err:
-            logger.exception(f"ERROR processing {artifact._location}")
+            logger.error(f"ERROR processing {artifact._location}:\n  {err}")
             if (stop_on_error):
                 stopswitch.set()
                 print("Please exit with ctrl-c")

--- a/source/fab/queue.py
+++ b/source/fab/queue.py
@@ -29,7 +29,8 @@ def _worker(queue: JoinableQueue,
             discovery: Dict[str, DiscoveryState],
             objects: List[Artifact],
             lock: LockT,
-            stopswitch: EventT):
+            stopswitch: EventT,
+            stop_on_error: bool=True):
 
     logger = logging.getLogger(__file__)
 
@@ -48,19 +49,21 @@ def _worker(queue: JoinableQueue,
             for new_artifact in new_artifacts:
                 queue.put(new_artifact)
         except TaskException as err:
-            logger.exception(f"ERROR processing {artifact}")
-            stopswitch.set()
-            print("Please exit with ctrl-c")
+            logger.exception(f"ERROR processing {artifact._location}")
+            if (stop_on_error):
+                stopswitch.set()
+                print("Please exit with ctrl-c")
         finally:
             queue.task_done()
 
 
 class QueueManager(object):
-    def __init__(self, n_workers: int, engine: Engine):
+    def __init__(self, n_workers: int, engine: Engine, stop_on_error: bool=True):
         self._queue: Queue = JoinableQueue()
         self._n_workers = n_workers
         self._workers: List[int] = []
         self._engine = engine
+        self._stop_on_error = stop_on_error
         self._mgr = Manager()
         self._discovery: Dict[str, DiscoveryState] = self._mgr.dict({})
         self._stopswitch: EventT = Event()
@@ -79,7 +82,8 @@ class QueueManager(object):
                                       self._discovery,
                                       self._objects,
                                       self._lock,
-                                      self._stopswitch))
+                                      self._stopswitch,
+                                      self._stop_on_error))
             process.start()
             self._workers.append(process)
 

--- a/source/fab/tasks/fortran.py
+++ b/source/fab/tasks/fortran.py
@@ -537,19 +537,21 @@ class FortranAnalyser(Task):
                 if end_nature is not None:
                     if end_nature != exp[0]:
                         end_message = 'Expected end of {exp} "{name}" ' \
-                                      'but found {found}'
+                                      'but found {found}: {line}'
                         end_values = {'exp': exp[0],
                                       'name': exp[1],
-                                      'found': end_nature}
+                                      'found': end_nature,
+                                      'line': line}
                         raise TaskException(
                             end_message.format(**end_values))
                 if end_name is not None:
                     if end_name != exp[1]:
                         end_message = 'Expected end of {exp} "{name}" ' \
-                                      'but found end of {found}'
+                                      'but found end of {found}: {line}'
                         end_values = {'exp': exp[0],
                                       'name': exp[1],
-                                      'found': end_name}
+                                      'found': end_name,
+                                      'line': line}
                         raise TaskException(
                             end_message.format(**end_values))
 


### PR DESCRIPTION
When a processing exception occurs, the worker will now display the error message and optionally try to exit the program.

The program doesn't actually exit, though. I think we might be seeing the [_Joining processes that use queues_](https://docs.python.org/3/library/multiprocessing.html#all-start-methods) problem? However, the user can now see that an error has occurred, with detail about the error, and be advised to exit manually.

Sample output with `stop_on_error=True`:
```
ERROR processing /home/h02/bblay/git/fab/tmp-workspace/templating_mod.f90:
  Expected end of module "templating_mod" but found function: END FUNCTION tpl_has_var_name
Please exit with ctrl-c
```

Sample output with `stop_on_error=False`:
```
ERROR processing /home/h02/bblay/git/fab/tmp-workspace/templating_mod.f90:
  Expected end of module "templating_mod" but found function: END FUNCTION tpl_has_var_name
ERROR processing /home/h02/bblay/git/fab/tmp-workspace/string_utils_mod.f90:
  Expected end of if "None" but found function: END FUNCTION str_starts_with
ERROR processing /home/h02/bblay/git/fab/tmp-workspace/metstats_timestep.f90:
  Expected end of if "None" but found end of where: END WHERE
ERROR processing /home/h02/bblay/git/fab/tmp-workspace/metstats_mod.f90:
  Expected end of if "None" but found subroutine: END SUBROUTINE metstats_allocate
ERROR processing /home/h02/bblay/git/fab/tmp-workspace/metstats_init.f90:
  Expected end of if "None" but found subroutine: END SUBROUTINE metstats_init
ERROR processing /home/h02/bblay/git/fab/tmp-workspace/logging_mod.f90:
  Expected end of if "None" but found subroutine: END SUBROUTINE read_nml_jules_prnt_control
ERROR processing /home/h02/bblay/git/fab/tmp-workspace/grid_utils_mod.f90:
  Expected end of if "None" but found function: END FUNCTION grid_create
ERROR processing /home/h02/bblay/git/fab/tmp-workspace/dictionary_mod.f90:
  Expected end of if "None" but found subroutine: END SUBROUTINE dict_get_int
ERROR processing /home/h02/bblay/git/fab/tmp-workspace/datetime_mod.f90:
  Expected end of module "datetime_mod" but found function: END FUNCTION datetime_clone
ERROR processing /home/h02/bblay/git/fab/tmp-workspace/data_cube_mod.f90:
  Expected end of module "data_cube_mod" but found function: END FUNCTION is_mdi
ERROR processing /home/h02/bblay/git/fab/tmp-workspace/cable_pack_mod.f90:
  Expected end of if "None" but found do:  END DO
ERROR processing /home/h02/bblay/git/fab/tmp-workspace/water_resources_drive.f90:
  Expected end of if "None" but found subroutine: END SUBROUTINE water_resources_drive
ERROR processing /home/h02/bblay/git/fab/tmp-workspace/vegcarb_jls.f90:
  Expected end of if "None" but found subroutine: END SUBROUTINE vegcarb
ERROR processing /home/h02/bblay/git/fab/tmp-workspace/veg-veg2a_jls_mod.f90:
  Expected end of if "None" but found subroutine: END SUBROUTINE veg2
ERROR processing /home/h02/bblay/git/fab/tmp-workspace/veg-veg1a_jls_mod.f90:
  Expected end of if "None" but found subroutine: END SUBROUTINE veg1
ERROR processing /home/h02/bblay/git/fab/tmp-workspace/triffid_jls.f90:
  Expected end of if "None" but found do: END DO
ERROR processing /home/h02/bblay/git/fab/tmp-workspace/sparm_jls_mod.f90:
  Expected end of if "None" but found do:  END DO
  ...
  ```