### PR TITLE
no scope for logical if

### DIFF
--- a/source/fab/tasks/fortran.py
+++ b/source/fab/tasks/fortran.py
@@ -444,7 +444,7 @@ class FortranAnalyser(Task):
                     continue
 
                 block_name: str = block_match.group(1) \
-                                  and block_match.group(2).lower()
+                    and block_match.group(2).lower()
                 block_nature: str = block_match.group(3).lower()
                 logger.debug('Found %s called "%s"', block_nature, block_name)
                 scope.append((block_nature, block_name))

--- a/source/fab/tasks/fortran.py
+++ b/source/fab/tasks/fortran.py
@@ -436,6 +436,13 @@ class FortranAnalyser(Task):
                 # Beware we want the value of a different group to the one we
                 # check the presence of.
                 #
+
+                # skip any IF without a THEN
+                # todo: discuss what can go in here - might it need a scope?
+                stripped = line.lower().strip()
+                if stripped.startswith("if") and "then" not in stripped:
+                    continue
+
                 block_name: str = block_match.group(1) \
                                   and block_match.group(2).lower()
                 block_nature: str = block_match.group(3).lower()


### PR DESCRIPTION
"logical ifs" (if without then, hope that's the correct term!) should not extend the scope.
Authored with Dave.

todo:
 - [x] why are we pasring ifs at all? spin out discussion