### PR TITLE
Grab step

### DIFF
--- a/run_configs/gcom/gcom_vdi/gcom_run.py
+++ b/run_configs/gcom/gcom_vdi/gcom_run.py
@@ -6,16 +6,15 @@
 ##############################################################################
 
 import os
-import shutil
 from pathlib import Path
 
 from fab.builder import Build
 from fab.config import Config
-from fab.constants import SOURCE_ROOT
 from fab.steps.analyse import Analyse
 from fab.steps.archive_objects import ArchiveObjects
 from fab.steps.compile_c import CompileC
 from fab.steps.compile_fortran import CompileFortran
+from fab.steps.grab import GrabFcm
 from fab.steps.preprocess import CPreProcessor, FortranPreProcessor
 from fab.steps.walk_source import FindSourceFiles
 from fab.util import TimerLogger
@@ -26,10 +25,9 @@ def gcom_object_archive_config():
 
     config = Config(label='gcom object archive', workspace=workspace)
 
-    config.grab_config = {("gcom", "~/svn/gcom/trunk/build"), }
-
     config.steps = [
-        FindSourceFiles(workspace / SOURCE_ROOT),  # template?
+        GrabFcm(src='fcm:gcom.xm_tr/build', revision='vn7.6', dst_label="gcom"),
+        FindSourceFiles(),
         CPreProcessor(),
         FortranPreProcessor(
             common_flags=[
@@ -55,23 +53,8 @@ def gcom_object_archive_config():
 
 def main():
 
-    # ignore this, it's not here
-    config = gcom_object_archive_config()
-    with TimerLogger("grabbing"):
-        grab_will_do_this(config.grab_config, config.workspace)
-
     with TimerLogger("gcom build"):
         Build(config=gcom_object_archive_config()).run()
-
-
-def grab_will_do_this(src_paths, workspace):
-    for label, src_path in src_paths:
-        shutil.copytree(
-            os.path.expanduser(src_path),
-            workspace / SOURCE_ROOT / label,
-            dirs_exist_ok=True,
-            ignore=shutil.ignore_patterns('.svn')
-        )
 
 
 if __name__ == '__main__':

--- a/run_configs/jules/jules_rose_suite/bin/build_jules.py
+++ b/run_configs/jules/jules_rose_suite/bin/build_jules.py
@@ -1,17 +1,10 @@
-#!/usr/bin/env python
 ##############################################################################
 # (c) Crown copyright Met Office. All rights reserved.
 # For further details please refer to the file COPYRIGHT
 # which you should have received as part of this distribution
 ##############################################################################
-
-import os
-import shutil
-from pathlib import Path
-
 from fab.builder import Build
 from fab.config import Config
-from fab.constants import SOURCE_ROOT
 from fab.steps.analyse import Analyse
 from fab.steps.compile_c import CompileC
 from fab.steps.compile_fortran import CompileFortran
@@ -19,21 +12,12 @@ from fab.steps.link_exe import LinkExe
 from fab.steps.preprocess import CPreProcessor, FortranPreProcessor
 from fab.steps.root_inc_files import RootIncFiles
 from fab.steps.walk_source import FindSourceFiles, EXCLUDE
-from fab.util import TimerLogger
+
+from grab_jules import jules_source
 
 
 def jules_config():
-    workspace = Path(os.path.dirname(__file__)) / "tmp-workspace" / 'jules'
-
-    config = Config(label='Jules Build', workspace=workspace)
-    # config.use_multiprocessing = False
-    config.debug_skip = True
-
-    # make this a step?
-    config.grab_config = {
-        ('src', '~/svn/jules/trunk/src'),
-        ('util', '~/svn/jules/trunk/utils')
-    }
+    config = Config(label='Jules Build', workspace=jules_source().workspace)
 
     unreferenced_dependencies = [
         'sunny', 'solpos', 'solang', 'redis', 'init_time', 'init_irrigation', 'init_urban', 'init_fire', 'init_drive',
@@ -46,12 +30,14 @@ def jules_config():
 
     config.steps = [
 
-        FindSourceFiles(workspace / SOURCE_ROOT, file_filtering=[
+        FindSourceFiles(file_filtering=[
             (['src/control/um/'], EXCLUDE),
             (['src/initialisation/um/'], EXCLUDE),
+            (['src/control/rivers-standalone/'], EXCLUDE),
+            (['src/initialisation/rivers-standalone/'], EXCLUDE),
             (['src/params/shared/cable_maths_constants_mod.F90'], EXCLUDE)]),
 
-        RootIncFiles(workspace / SOURCE_ROOT),
+        RootIncFiles(),
 
         CPreProcessor(),
 
@@ -61,20 +47,18 @@ def jules_config():
         ),
 
         Analyse(root_symbol='jules', unreferenced_deps=unreferenced_dependencies),
-        # Analyse(),
 
         CompileC(),
 
         CompileFortran(
-            # compiler=os.path.expanduser('~/.conda/envs/sci-fab/bin/mpifort'),
             compiler='gfortran',
             common_flags=[
                 '-c', '-fallow-argument-mismatch',
                 '-J', '$output'],
 
         ),
+
         LinkExe(
-            # linker=os.path.expanduser('~/.conda/envs/sci-fab/bin/mpifort'),
             linker='mpifort',
             output_fpath='$output/../jules.exe',
             flags=['-lm']),
@@ -82,26 +66,6 @@ def jules_config():
     return config
 
 
-def main():
-
-    config = jules_config()
-
-    # ignore this, it's not here
-    with TimerLogger("grabbing"):
-        grab_will_do_this(config.grab_config, config.workspace)
-
-    Build(config=config, ).run()
-
-
-def grab_will_do_this(src_paths, workspace):
-    for label, src_path in src_paths:
-        shutil.copytree(
-            os.path.expanduser(src_path),
-            workspace / SOURCE_ROOT / label,
-            dirs_exist_ok=True,
-            ignore=shutil.ignore_patterns('.svn')
-        )
-
-
 if __name__ == '__main__':
-    main()
+    config = jules_config()
+    Build(config=config, ).run()

--- a/run_configs/jules/jules_rose_suite/bin/grab_jules.py
+++ b/run_configs/jules/jules_rose_suite/bin/grab_jules.py
@@ -1,0 +1,32 @@
+##############################################################################
+# (c) Crown copyright Met Office. All rights reserved.
+# For further details please refer to the file COPYRIGHT
+# which you should have received as part of this distribution
+##############################################################################
+import os
+from pathlib import Path
+
+from fab.builder import Build
+from fab.config import Config
+from fab.steps.grab import GrabFcm
+
+
+def jules_source():
+
+    # default to 22411, release 6.3, feb 28 2022
+    revision = os.getenv('JULES_REVISION') or "22411"
+    workspace = Path(os.path.dirname(__file__)) / "tmp-workspace" / 'jules'
+
+    return Config(
+        label='Jules Source',
+        workspace=workspace,
+        steps=[
+            GrabFcm(src=f'fcm:jules.xm_tr/src@{revision}', dst_label='src'),
+            GrabFcm(src=f'fcm:jules.xm_tr/utils@{revision}', dst_label='utils'),
+        ]
+    )
+
+
+if __name__ == '__main__':
+    config = jules_source()
+    Build(config=config).run()

--- a/run_configs/jules/jules_rose_suite/bin/run_py.sh
+++ b/run_configs/jules/jules_rose_suite/bin/run_py.sh
@@ -1,0 +1,15 @@
+##############################################################################
+# (c) Crown copyright Met Office. All rights reserved.
+# For further details please refer to the file COPYRIGHT
+# which you should have received as part of this distribution
+##############################################################################
+
+# Helper script to activate the sci-fab conda environment before invoking python, for rose suites.
+
+. /etc/profile.d/conda.sh
+conda activate sci-fab
+
+BIN_FOLDER=$(dirname "$0")
+export PYTHONPATH=$PYTHONPATH:$BIN_FOLDER
+
+python -m $1

--- a/run_configs/jules/jules_rose_suite/rose-suite.conf
+++ b/run_configs/jules/jules_rose_suite/rose-suite.conf
@@ -1,0 +1,4 @@
+[env]
+
+[jinja2:suite.rc]
+JULES_REVISION='vn6.3'

--- a/run_configs/jules/jules_rose_suite/suite.rc
+++ b/run_configs/jules/jules_rose_suite/suite.rc
@@ -1,0 +1,30 @@
+[scheduling]
+    [[dependencies]]
+        graph = """
+            grab_jules => build_jules
+        """
+
+[runtime]
+
+    [[common]]
+        [[[job]]]
+            batch system = slurm
+            execution time limit = PT10M
+        [[[directives]]]
+            --mem=1024
+#           --ntasks=4
+            --cpus-per-task=4
+            --export=NONE
+        [[[environment]]]
+            FAB_WORKSPACE=$SCRATCH/fab_workspace
+            OMPI_FC=gfortran
+
+    [[grab_jules]]
+        inherit = common
+        script = run_py.sh grab_jules
+        [[[environment]]]
+            JULES_REVISION={{ JULES_REVISION }}
+
+    [[build_jules]]
+        inherit = common
+        script = run_py.sh build_jules

--- a/run_configs/jules/jules_vdi/jules_run.py
+++ b/run_configs/jules/jules_vdi/jules_run.py
@@ -18,7 +18,6 @@ from fab.steps.link_exe import LinkExe
 from fab.steps.preprocess import CPreProcessor, FortranPreProcessor
 from fab.steps.root_inc_files import RootIncFiles
 from fab.steps.walk_source import FindSourceFiles, EXCLUDE
-from fab.util import TimerLogger
 
 
 def jules_config():

--- a/run_configs/jules/jules_vdi/jules_run.py
+++ b/run_configs/jules/jules_vdi/jules_run.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python
+##############################################################################
+# (c) Crown copyright Met Office. All rights reserved.
+# For further details please refer to the file COPYRIGHT
+# which you should have received as part of this distribution
+##############################################################################
+
+import os
+from pathlib import Path
+
+from fab.builder import Build
+from fab.config import Config
+from fab.steps.analyse import Analyse
+from fab.steps.compile_c import CompileC
+from fab.steps.compile_fortran import CompileFortran
+from fab.steps.grab import GrabFcm
+from fab.steps.link_exe import LinkExe
+from fab.steps.preprocess import CPreProcessor, FortranPreProcessor
+from fab.steps.root_inc_files import RootIncFiles
+from fab.steps.walk_source import FindSourceFiles, EXCLUDE
+from fab.util import TimerLogger
+
+
+def jules_config():
+
+    # release 6.3, feb 28 2022
+    revision = os.getenv('JULES_REVISION') or "vn6.3"
+
+    workspace = Path(os.path.dirname(__file__)) / "tmp-workspace" / 'jules'
+
+    config = Config(label='Jules Build', workspace=workspace)
+    # config.use_multiprocessing = False
+    config.debug_skip = True
+
+    unreferenced_dependencies = [
+        'sunny', 'solpos', 'solang', 'redis', 'init_time', 'init_irrigation', 'init_urban', 'init_fire', 'init_drive',
+        'init_imogen', 'init_prescribed_data', 'init_vars_tmp', 'imogen_check', 'imogen_update_clim', 'control',
+        'imogen_update_carb', 'next_time', 'sow', 'emerge', 'develop', 'partition', 'radf_co2', 'radf_non_co2',
+        'adf_ch4gcm_anlg', 'drdat', 'clim_calc', 'diffcarb_land_co2', 'ocean_co2', 'diffcarb_land_ch4',
+        'diff_atmos_ch4', 'day_calc', 'response', 'radf_ch4', 'gcm_anlg', 'delta_temp', 'rndm', 'invert', 'vgrav',
+        'conversions_mod', 'water_constants_mod', 'planet_constants_mod', 'veg_param_mod', 'flake_interface'
+    ]
+
+    config.steps = [
+
+        GrabFcm(src=f'fcm:jules.xm_tr/src@{revision}', dst_label='src'),
+        GrabFcm(src=f'fcm:jules.xm_tr/utils@{revision}', dst_label='utils'),
+
+        FindSourceFiles(file_filtering=[
+            (['src/control/um/'], EXCLUDE),
+            (['src/initialisation/um/'], EXCLUDE),
+            (['src/control/rivers-standalone/'], EXCLUDE),
+            (['src/initialisation/rivers-standalone/'], EXCLUDE),
+            (['src/params/shared/cable_maths_constants_mod.F90'], EXCLUDE)]),
+
+        RootIncFiles(),
+
+        CPreProcessor(),
+
+        FortranPreProcessor(
+            preprocessor='cpp',
+            common_flags=['-traditional-cpp', '-P', '-DMPI_DUMMY', '-DNCDF_DUMMY', '-I', '$output']
+        ),
+
+        Analyse(root_symbol='jules', unreferenced_deps=unreferenced_dependencies),
+
+        CompileC(),
+
+        CompileFortran(
+            compiler='gfortran',
+            common_flags=[
+                '-c', '-fallow-argument-mismatch',
+                '-J', '$output'],
+
+        ),
+
+        LinkExe(
+            linker='mpifort',
+            output_fpath='$output/../jules.exe',
+            flags=['-lm']),
+    ]
+    return config
+
+
+def main():
+
+    config = jules_config()
+
+    Build(config=config, ).run()
+
+
+if __name__ == '__main__':
+    main()

--- a/source/fab/config.py
+++ b/source/fab/config.py
@@ -7,7 +7,7 @@ from fnmatch import fnmatch
 from multiprocessing import cpu_count
 from pathlib import Path
 from string import Template
-from typing import List, Set
+from typing import List
 
 from fab.constants import BUILD_OUTPUT, SOURCE_ROOT
 from fab.steps import Step
@@ -16,15 +16,11 @@ from fab.steps import Step
 class Config(object):
 
     def __init__(self, label, workspace,
-                 grab_config=None, steps: List[Step] = None,
+                 source_root=None,
+                 steps: List[Step] = None,
                  use_multiprocessing=True, n_procs=max(1, cpu_count() - 1), debug_skip=False):
         self.label = label
         self.workspace = workspace
-
-        # source config
-        self.grab_config: Set = grab_config or set()
-        # file_filtering = file_filtering or []
-        # self.path_filters: List[PathFilter] = [PathFilter(*i) for i in file_filtering]
 
         # build steps
         self.steps: List[Step] = steps or []  # default, zero-config steps here
@@ -33,6 +29,8 @@ class Config(object):
         self.use_multiprocessing = use_multiprocessing
         self.n_procs = n_procs
         self.debug_skip = debug_skip
+
+        self.source_root = source_root or self.workspace / SOURCE_ROOT
 
 
 class PathFilter(object):

--- a/source/fab/metrics.py
+++ b/source/fab/metrics.py
@@ -157,7 +157,7 @@ def metrics_summary(metrics_folder: Path):
     metrics_folder.mkdir(exist_ok=True)
 
     # graphs for individual steps
-    step_names = ['preprocessed_fortran', 'preprocessed_c', 'compile fortran']
+    step_names = ['preprocess fortran', 'preprocess c', 'compile fortran']
     for step_name in step_names:
         if step_name not in metrics:
             logger.error(f'no step metrics called {step_name}')

--- a/source/fab/steps/grab.py
+++ b/source/fab/steps/grab.py
@@ -1,0 +1,69 @@
+##############################################################################
+# (c) Crown copyright Met Office. All rights reserved.
+# For further details please refer to the file COPYRIGHT
+# which you should have received as part of this distribution
+##############################################################################
+import os
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import Dict
+
+from fab.steps import Step
+from fab.util import run_command
+
+
+class GrabBase(Step, ABC):
+    """
+    All grab steps require a source and a folder in which to put it.
+
+    """
+    def __init__(self, src, dst_label, name=None):
+        """
+        Args:
+            - src: The source location to grab. The nature of this is depends on the subclass.
+            - dst_label: The name of a sub folder in the project workspace, in which to put the source.
+
+        """
+        super().__init__(name=name or f'{self.__class__.__name__} {dst_label}'.strip())
+        self.src: str = src
+        self.dst_label: str = dst_label
+
+    @abstractmethod
+    def run(self, artefact_store: Dict, config):
+        super().run(artefact_store, config)
+        if not config.source_root.exists():
+            config.source_root.mkdir(parents=True, exist_ok=True)
+
+
+class GrabFolder(GrabBase):
+    """
+    Step to copy a source folder to the project workspace.
+
+    """
+    def run(self, artefact_store: Dict, config):
+        super().run(artefact_store, config)
+
+        # we want the source folder to end with a / for rsync because we don't want it to create a sub folder
+        src = os.path.expanduser(self.src)
+        if not src.endswith('/'):
+            src += '/'
+
+        dst: Path = config.source_root / self.dst_label
+        dst.mkdir(parents=True, exist_ok=True)
+
+        command = ['rsync', '-ruq', src, str(dst)]
+        run_command(command)
+
+
+# todo: checkout operation might be quicker for some use cases, add an option for this?
+class GrabFcm(GrabBase):
+
+    def __init__(self, src, dst_label, revision=None, name=None):
+        super().__init__(src, dst_label, name=name or f'{self.__class__.__name__} {dst_label} {revision}'.strip())
+        self.revision = revision
+
+    def run(self, artefact_store: Dict, config):
+        super().run(artefact_store, config)
+
+        src = f'{self.src}@{self.revision}' if self.revision else self.src
+        run_command(['fcm', 'export', '--force', src, str(config.source_root / self.dst_label)])

--- a/source/fab/steps/root_inc_files.py
+++ b/source/fab/steps/root_inc_files.py
@@ -25,10 +25,10 @@ logger = logging.getLogger(__name__)
 
 class RootIncFiles(Step):
 
-    def __init__(self, source_root: Path, build_output: Optional[Path] = None, name="root inc files"):
+    def __init__(self, source_root=None, build_output: Optional[Path] = None, name="root inc files"):
         super().__init__(name)
         self.source_root = source_root
-        self.build_output = build_output or source_root.parent / BUILD_OUTPUT
+        self.build_output = build_output
 
     def run(self, artefact_store, config):
         """
@@ -40,6 +40,9 @@ class RootIncFiles(Step):
         """
         super().run(artefact_store, config)
 
+        source_root = self.source_root or config.source_root
+        build_output = self.build_output or source_root.parent / BUILD_OUTPUT
+
         warnings.warn("RootIncFiles is deprecated as .inc files are due to be removed.", DeprecationWarning)
 
         # inc files all go in the root - they're going to be removed altogether, soon
@@ -48,7 +51,7 @@ class RootIncFiles(Step):
 
             # don't copy from the output root to the output root!
             # (i.e ancillary files from a previous run)
-            if fpath.parent == self.build_output:
+            if fpath.parent == build_output:
                 continue
 
             # check for name clash
@@ -56,5 +59,5 @@ class RootIncFiles(Step):
                 raise FileExistsError(f"name clash for inc file: {fpath}")
 
             logger.debug(f"copying inc file {fpath}")
-            shutil.copy(fpath, self.build_output)
+            shutil.copy(fpath, build_output)
             inc_copied.add(fpath.name)

--- a/tests/unit_tests/steps/test_grab.py
+++ b/tests/unit_tests/steps/test_grab.py
@@ -1,0 +1,63 @@
+##############################################################################
+# (c) Crown copyright Met Office. All rights reserved.
+# For further details please refer to the file COPYRIGHT
+# which you should have received as part of this distribution
+##############################################################################
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+from fab.steps.grab import GrabFolder, GrabFcm
+
+
+class TestGrabFolder(object):
+
+    def test_trailing_slash(self):
+        self._common(grab_src='/grab/source/', expect_grab_src='/grab/source/')
+
+    def test_no_trailing_slash(self):
+        self._common(grab_src='/grab/source', expect_grab_src='/grab/source/')
+
+    def _common(self, grab_src, expect_grab_src):
+        source_root = Path('/workspace/source')
+        dst_label = 'bar'
+        grabber = GrabFolder(src=grab_src, dst_label=dst_label)
+
+        mock_config = SimpleNamespace(source_root=source_root)
+        with mock.patch('pathlib.Path.mkdir'):
+            with mock.patch('fab.steps.grab.run_command') as mock_run:
+                grabber.run(artefact_store={}, config=mock_config)
+
+        expect_dst = mock_config.source_root / dst_label
+        mock_run.assert_called_once_with(['rsync', '-ruq', expect_grab_src, str(expect_dst)])
+
+
+class TestGrabFcm(object):
+
+    def test_no_revision(self):
+        source_root = Path('/workspace/source')
+        source_url = '/www.example.com/bar'
+        dst_label = 'bar'
+        grabber = GrabFcm(src=source_url, dst_label=dst_label)
+
+        mock_config = SimpleNamespace(source_root=source_root)
+        with mock.patch('pathlib.Path.mkdir'):
+            with mock.patch('fab.steps.grab.run_command') as mock_run:
+                grabber.run(artefact_store={}, config=mock_config)
+
+        mock_run.assert_called_once_with(['fcm', 'export', '--force', source_url, str(source_root / dst_label)])
+
+    def test_revision(self):
+        source_root = Path('/workspace/source')
+        source_url = '/www.example.com/bar'
+        dst_label = 'bar'
+        revision = '42'
+        grabber = GrabFcm(src=source_url, dst_label=dst_label, revision=revision)
+
+        mock_config = SimpleNamespace(source_root=source_root)
+        with mock.patch('pathlib.Path.mkdir'):
+            with mock.patch('fab.steps.grab.run_command') as mock_run:
+                grabber.run(artefact_store={}, config=mock_config)
+
+        mock_run.assert_called_once_with(
+            ['fcm', 'export', '--force', f'{source_url}@{revision}', str(source_root / dst_label)])


### PR DESCRIPTION
This PRs turn the grab config into a Step.

This change improves the grab config; from a special section referring to our ~/.svn folders, to now using fcm urls, which looks much better and makes the code easier for other people to run. The grab changes to the UM build script are a good example of this improvement.

This change also reduces the config required from the user, because the grab step and other code-searching steps now automatically share a sensible default folder.

Notes:
 - We copied the grab step from our latest code.
 - Because we've put the source root into the config,
    as required by the grab step we copied,
    the FindSourceFiles and RootIncFiles steps
    no longer need this configuration passed in.
 - This change enabled us to remove the `# ignore this, it's not here` comments and `grab_will_do_this()`
    functions from the build scripts.
 - We've made a JULES build script for rose - with the grab task separate from the build task,
    as this use case was recently discussed in a standup (the UM can't access the internet).
    This JULES rose config also shows some simple config reuse, as the build step reuses an attribute from the grab config,
    which reduces repetition and the likelihood of human error.
 - We could have shared config code between the vdi and rose build configs,
    but we decided to keep things separate and simple - happy to change that!

