### PR TITLE
optional archive step with sensible linker defaults

### DIFF
--- a/run_configs/jules/build_jules.py
+++ b/run_configs/jules/build_jules.py
@@ -7,6 +7,8 @@ import logging
 import os
 from argparse import ArgumentParser
 
+from fab.steps.archive_objects import ArchiveObjects
+
 from fab.build_config import BuildConfig
 from fab.steps.analyse import Analyse
 from fab.steps.compile_c import CompileC
@@ -70,7 +72,13 @@ def jules_config(revision=None):
             common_flags=[
                 '-c',
                 '-J', '$output'],
+            # required for newer compilers
+            # path_flags=[
+            #     AddFlags('*/io/dump/read_dump_mod.f90', ['-fallow-argument-mismatch']),
+            # ]
         ),
+
+        ArchiveObjects(),
 
         LinkExe(
             linker='mpifort',

--- a/run_configs/um/build_um.py
+++ b/run_configs/um/build_um.py
@@ -12,6 +12,8 @@ import os
 import warnings
 from pathlib import Path
 
+from fab.steps.archive_objects import ArchiveObjects
+
 from fab.steps.preprocess import c_preprocessor, fortran_preprocessor
 
 from fab.artefacts import CollectionGetter
@@ -190,12 +192,15 @@ def um_atmos_safe_config():
                 AddFlags("$output/um/*", ['-I' + gcom_build]),
                 AddFlags("$output/jules/*", ['-I' + gcom_build]),
 
-                # todo: allow multiple filters per instance?
+                # required for newer compilers
+                # # todo: allow multiple filters per instance?
                 # *[AddFlags(*i) for i in ALLOW_MISMATCH_FLAGS]
             ]
         ),
 
         # todo: ArchiveObjects() first? If nothing else, it makes linker error messages more manageable.
+
+        ArchiveObjects(),
 
         #
         LinkExe(
@@ -210,6 +215,8 @@ def um_atmos_safe_config():
 
     return config
 
+
+# required for newer compilers
 
 # # todo: allow a list of filters?
 # ALLOW_MISMATCH_FLAGS = [

--- a/source/fab/artefacts.py
+++ b/source/fab/artefacts.py
@@ -41,7 +41,7 @@ class CollectionGetter(ArtefactsGetter):
 
     def __call__(self, artefact_store):
         super().__call__(artefact_store)
-        return artefact_store[self.collection_name]
+        return artefact_store.get(self.collection_name, [])
 
 
 class CollectionConcat(ArtefactsGetter):
@@ -135,3 +135,6 @@ class FilterBuildTree(ArtefactsGetter):
         super().__call__(artefact_store)
         source_tree: Dict[Path, AnalysedFile] = artefact_store[self.collection_name]
         return filter_source_tree(source_tree=source_tree, suffixes=self.suffixes)
+
+
+CompiledFortranAndC = CollectionConcat(['compiled_c', 'compiled_fortran'])

--- a/source/fab/steps/compile_c.py
+++ b/source/fab/steps/compile_c.py
@@ -51,7 +51,7 @@ class CompileC(MpExeStep):
             raise RuntimeError(f"There were {len(errors)} errors compiling {len(to_compile)} c files:\n{err_msg}")
 
         # results
-        compiled_c = [result for result in results if isinstance(result, CompiledFile)]
+        compiled_c = [result.output_fpath for result in results if isinstance(result, CompiledFile)]
         logger.info(f"compiled {len(compiled_c)} c files")
 
         artefact_store['compiled_c'] = compiled_c

--- a/source/fab/steps/compile_fortran.py
+++ b/source/fab/steps/compile_fortran.py
@@ -90,7 +90,7 @@ class CompileFortran(MpExeStep):
             logger.error(f"there were still {len(to_compile)} files left to compile")
             exit(1)
 
-        artefact_store['compiled_fortran'] = all_compiled
+        artefact_store['compiled_fortran'] = [i.output_fpath for i in all_compiled]
 
     def get_compile_next(self, already_compiled_files: Set[Path], to_compile: Set[AnalysedFile]):
 

--- a/source/fab/steps/link_exe.py
+++ b/source/fab/steps/link_exe.py
@@ -8,17 +8,31 @@ Link an executable.
 
 """
 import logging
+import os
 from string import Template
 from typing import List
 
+from fab import artefacts
 from fab.constants import BUILD_OUTPUT
-from fab.steps import Step
+from fab.steps import Step, archive_objects
 from fab.util import log_or_dot, run_command
-from fab.artefacts import ArtefactsGetter, CollectionConcat
+from fab.artefacts import ArtefactsGetter, CollectionGetter
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_SOURCE_GETTER = CollectionConcat(['compiled_c', 'compiled_fortran'])
+
+class DefaultLinkerSource(ArtefactsGetter):
+    """
+    A source getter specifically for linking.
+    Looks for the default output from ArchiveObjects, falls back to artefacts.CompiledFortranAndC.
+    This allows a link step to work with or without a preceding object archive step.
+    """
+    def __call__(self, artefact_store):
+        return CollectionGetter(archive_objects.DEFAULT_COLLECTION_NAME)(artefact_store) \
+               or artefacts.CompiledFortranAndC(artefact_store)
+
+
+DEFAULT_SOURCE_GETTER = DefaultLinkerSource()
 
 
 class LinkExe(Step):
@@ -54,11 +68,13 @@ class LinkExe(Step):
 
         compiled_files = self.source_getter(artefact_store)
 
-        command = [self.linker]
+        command = self.linker.split()
         command.extend(['-o', Template(self.output_fpath).substitute(
             output=str(config.project_workspace / BUILD_OUTPUT))])
-        command.extend([str(a.output_fpath) for a in compiled_files])
+        command.extend(map(str, compiled_files))
+
         # note: this must this come after the list of object files?
+        command.extend(os.getenv('LDFLAGS', []).split())
         command.extend(self.flags)
 
         log_or_dot(logger, 'Link running command: ' + ' '.join(command))

--- a/source/fab/util.py
+++ b/source/fab/util.py
@@ -97,7 +97,7 @@ class TimerLogger(Timer):
                 logger.info(f"{self.label} took {seconds:.3f}s")
 
 
-# todo: better as a named tuple?
+# todo: this is only needed for fortran compiling - move it there as a private class and stop using in c compiler
 class CompiledFile(object):
     def __init__(self, analysed_file, output_fpath):
         self.analysed_file = analysed_file

--- a/tests/unit_tests/steps/test_compile_fortran.py
+++ b/tests/unit_tests/steps/test_compile_fortran.py
@@ -48,13 +48,14 @@ class Test_run(object):
         artefact_store = {'build_tree': {af.fpath: af for af in analysed_files}}
 
         def mp_return(items, func):
-            return [CompiledFile(analysed_file=i, output_fpath=None) for i in items]
+            return [CompiledFile(analysed_file=i, output_fpath=i.fpath.with_suffix('.o')) for i in items]
 
         with mock.patch('fab.steps.compile_fortran.CompileFortran.run_mp', side_effect=mp_return):
             compiler.run(artefact_store, config=None)
 
-        compiled = [i.analysed_file for i in artefact_store['compiled_fortran']]
-        assert compiled == list(reversed(analysed_files))
+        compiled = artefact_store['compiled_fortran']
+        expected = [i.fpath.with_suffix('.o') for i in reversed(analysed_files)]
+        assert compiled == expected
 
     def test_exception(self, compiler, analysed_files):
         # Like vanilla but run_mp returns an exception from the compiler.

--- a/tests/unit_tests/tasks/test_common.py
+++ b/tests/unit_tests/tasks/test_common.py
@@ -4,7 +4,6 @@ Test test_common.py.
 """
 from pathlib import Path
 from unittest import mock
-from unittest.mock import Mock
 
 from fab.steps.archive_objects import ArchiveObjects
 from fab.steps.link_exe import LinkExe
@@ -15,12 +14,18 @@ class TestLinkExe(object):
         # ensure the command is formed correctly, with the flags at the end (why?!)
         linker = LinkExe(linker='foolink', flags=['-fooflag', '-barflag'], output_fpath='foo.exe')
 
-        with mock.patch('fab.steps.link_exe.run_command') as mock_run:
-            linker.run(
-                artefact_store={'compiled_fortran': [Mock(output_fpath='foo.o'), Mock(output_fpath='bar.o')]},
-                config=mock.Mock(project_workspace=Path('workspace')))
+        with mock.patch('os.getenv', return_value='-L/foo1/lib -L/foo2/lib'):
+            with mock.patch('fab.steps.link_exe.run_command') as mock_run:
+                linker.run(
+                    artefact_store={'compiled_fortran': ['foo.o', 'bar.o']},
+                    config=mock.Mock(project_workspace=Path('workspace')))
 
-        mock_run.assert_called_with(['foolink', '-o', 'foo.exe', 'foo.o', 'bar.o', '-fooflag', '-barflag'])
+        mock_run.assert_called_with([
+            'foolink', '-o', 'foo.exe',
+            'foo.o', 'bar.o',
+            '-L/foo1/lib', '-L/foo2/lib',
+            '-fooflag', '-barflag',
+        ])
 
 
 class TestArchiveObjects(object):
@@ -29,7 +34,7 @@ class TestArchiveObjects(object):
         archiver = ArchiveObjects(archiver='fooarc', output_fpath='$output/foo.a')
 
         with mock.patch('fab.steps.archive_objects.run_command') as mock_run:
-            artefact_store = {'compiled_fortran': [Mock(output_fpath='foo.o'), Mock(output_fpath='bar.o')]}
+            artefact_store = {'compiled_fortran': ['foo.o', 'bar.o']}
             archiver.run(artefact_store=artefact_store, config=mock.Mock(project_workspace=Path('workspace')))
 
         mock_run.assert_called_with(['fooarc', 'cr', 'workspace/build_output/foo.a', 'foo.o', 'bar.o'])


### PR DESCRIPTION
Problem: Linker error messages include the command which was run. This can contain thousands of object file paths, making the output difficult to navigate.

Solution: This PR aids config development by allowing an optional archive step before linking, reducing the size of linker error messages. This is achieved by creating a new default ArtefactGetter for the linker, which searches for an object archive artefact and otherwise falls back to the compiled files artefacts.