### PR TITLE
Misc tidy 1

### DIFF
--- a/run_configs/test_all.sh
+++ b/run_configs/test_all.sh
@@ -1,0 +1,12 @@
+set -e
+
+cd ~/git/fab/run_configs/gcom
+python -m grab_gcom
+python -m build_gcom_ar
+python -m build_gcom_so
+
+cd ../jules
+python -m build_jules
+
+cd ../um
+python -m build_um

--- a/source/fab/dep_tree.py
+++ b/source/fab/dep_tree.py
@@ -161,14 +161,6 @@ def _extract_sub_tree(src_tree: Dict[Path, AnalysedFile], key: Path,
             src_tree=src_tree, key=file_dep, dst_tree=dst_tree, missing=missing, verbose=verbose, indent=indent + 1)
 
 
-def by_type(iterable, cls):
-    """
-    Find all the elements of an iterable which are of a given type.
-
-    """
-    return filter(lambda i: isinstance(i, cls), iterable)
-
-
 def add_mo_commented_file_deps(source_tree: Dict[Path, AnalysedFile]):
     """
     Handle dependencies from Met Office "DEPENDS ON:" code comments which refer to a c file.

--- a/source/fab/metrics.py
+++ b/source/fab/metrics.py
@@ -153,9 +153,6 @@ def metrics_summary(metrics_folder: Path):
     logger.debug(f'metrics_summary: got metrics for: {metrics.keys()}')
     metrics_folder.mkdir(parents=True, exist_ok=True)
 
-    metrics_folder = Path(metrics_folder)
-    metrics_folder.mkdir(exist_ok=True)
-
     # graphs for individual steps
     step_names = ['preprocess fortran', 'preprocess c', 'compile fortran']
     for step_name in step_names:

--- a/source/fab/steps/__init__.py
+++ b/source/fab/steps/__init__.py
@@ -4,10 +4,11 @@
 # which you should have received as part of this distribution
 ##############################################################################
 import multiprocessing
+from abc import ABC, abstractmethod
 from typing import Dict
 
 
-class Step(object):
+class Step(ABC):
     """
     Base class for build steps.
 
@@ -18,6 +19,7 @@ class Step(object):
     def __init__(self, name):
         self.name = name
 
+    @abstractmethod
     def run(self, artefact_store: Dict, config):
         """
         Process some input artefacts, create some output artefacts. Defined in the subclass.

--- a/source/fab/steps/compile_c.py
+++ b/source/fab/steps/compile_c.py
@@ -59,7 +59,9 @@ class CompileC(MpExeStep):
     def _compile_file(self, analysed_file: AnalysedFile):
         command = [self.exe]
         command.extend(self.flags.flags_for_path(
-            path=analysed_file.fpath, source_root=self._config.source_root, workspace=self._config.project_workspace))
+            path=analysed_file.fpath,
+            source_root=self._config.source_root,
+            project_workspace=self._config.project_workspace))
         command.append(str(analysed_file.fpath))
 
         output_file = analysed_file.fpath.with_suffix('.o')

--- a/source/fab/steps/compile_fortran.py
+++ b/source/fab/steps/compile_fortran.py
@@ -13,9 +13,9 @@ from typing import List, Set, Dict
 
 from fab.metrics import send_metric
 
-from fab.dep_tree import AnalysedFile, by_type
+from fab.dep_tree import AnalysedFile
 from fab.steps.mp_exe import MpExeStep
-from fab.util import CompiledFile, log_or_dot_finish, log_or_dot, run_command, Timer
+from fab.util import CompiledFile, log_or_dot_finish, log_or_dot, run_command, Timer, by_type
 from fab.artefacts import ArtefactsGetter, FilterBuildTree
 
 logger = logging.getLogger(__name__)
@@ -121,7 +121,7 @@ class CompileFortran(MpExeStep):
             command.extend(self.flags.flags_for_path(
                 path=analysed_file.fpath,
                 source_root=self._config.source_root,
-                workspace=self._config.project_workspace))
+                project_workspace=self._config.project_workspace))
             command.append(str(analysed_file.fpath))
 
             output_fpath = analysed_file.fpath.with_suffix('.o')

--- a/source/fab/steps/grab.py
+++ b/source/fab/steps/grab.py
@@ -24,7 +24,7 @@ class GrabBase(Step, ABC):
             - dst_label: The name of a sub folder in the project workspace, in which to put the source.
 
         """
-        super().__init__(name=name or f'{self.__class__.__name__} {dst_label}'.strip())
+        super().__init__(name=name or f'{self.__class__.__name__} {dst_label or src}'.strip())
         self.src: str = src
         self.dst_label: str = dst_label
 

--- a/source/fab/steps/preprocess.py
+++ b/source/fab/steps/preprocess.py
@@ -13,9 +13,8 @@ from typing import List
 
 from fab.metrics import send_metric
 
-from fab.dep_tree import by_type
 from fab.steps.mp_exe import MpExeStep
-from fab.util import log_or_dot_finish, input_to_output_fpath, log_or_dot, run_command, Timer
+from fab.util import log_or_dot_finish, input_to_output_fpath, log_or_dot, run_command, Timer, by_type
 from fab.artefacts import ArtefactsGetter, SuffixFilter
 
 logger = logging.getLogger(__name__)
@@ -88,7 +87,7 @@ class PreProcessor(MpExeStep):
             # output_fpath = self.output_path(fpath)
             output_fpath = input_to_output_fpath(
                 source_root=self._config.source_root,
-                workspace=self._config.project_workspace,
+                project_workspace=self._config.project_workspace,
                 input_path=fpath).with_suffix(self.output_suffix)
 
             # for dev speed, but this could become a good time saver with, e.g, hashes or something
@@ -101,7 +100,7 @@ class PreProcessor(MpExeStep):
 
             command = [self.exe]
             command.extend(self.flags.flags_for_path(
-                path=fpath, source_root=self._config.source_root, workspace=self._config.project_workspace))
+                path=fpath, source_root=self._config.source_root, project_workspace=self._config.project_workspace))
 
             # input and output files
             command.append(str(fpath))

--- a/source/fab/steps/walk_source.py
+++ b/source/fab/steps/walk_source.py
@@ -13,7 +13,6 @@ from typing import Optional, List, Tuple
 
 from fab.build_config import PathFilter
 
-from fab.constants import BUILD_OUTPUT
 from fab.steps import Step
 from fab.util import file_walk
 
@@ -58,7 +57,6 @@ class FindSourceFiles(Step):
         super().run(artefact_store, config)
 
         source_root = self.source_root or config.source_root
-        build_output = self.build_output or source_root.parent / BUILD_OUTPUT
 
         # file filtering
         filtered_fpaths = []
@@ -78,14 +76,5 @@ class FindSourceFiles(Step):
 
         if not filtered_fpaths:
             raise RuntimeError("no source files found after filtering")
-
-        # create output folders
-        # todo: separate step for folder creation?
-        input_folders = set()
-        for fpath in filtered_fpaths:
-            input_folders.add(fpath.parent.relative_to(source_root))
-        for input_folder in input_folders:
-            path = build_output / input_folder
-            path.mkdir(parents=True, exist_ok=True)
 
         artefact_store[self.output_collection] = filtered_fpaths

--- a/source/fab/util.py
+++ b/source/fab/util.py
@@ -104,9 +104,9 @@ class CompiledFile(object):
         self.output_fpath = output_fpath
 
 
-def input_to_output_fpath(source_root: Path, workspace: Path, input_path: Path):
+def input_to_output_fpath(source_root: Path, project_workspace: Path, input_path: Path):
     rel_path = input_path.relative_to(source_root)
-    return workspace / BUILD_OUTPUT / rel_path
+    return project_workspace / BUILD_OUTPUT / rel_path
 
 
 def case_insensitive_replace(in_str: str, find: str, replace_with: str):
@@ -132,3 +132,11 @@ def suffix_filter(fpaths: Iterable[Path], suffixes: Iterable[str]):
     """
     # todo: Just return the iterator from filter. Let the caller decide whether to turn into a list.
     return list(filter(lambda fpath: fpath.suffix in suffixes, fpaths))
+
+
+def by_type(iterable, cls):
+    """
+    Find all the elements of an iterable which are of a given type.
+
+    """
+    return filter(lambda i: isinstance(i, cls), iterable)

--- a/tests/unit_tests/test_config.py
+++ b/tests/unit_tests/test_config.py
@@ -17,7 +17,7 @@ class TestAddFlags(object):
             fpath=Path(f"/workspace/{SOURCE_ROOT}/foo/bar.c"),
             input_flags=my_flags,
             source_root=workspace / SOURCE_ROOT,
-            workspace=workspace)
+            project_workspace=workspace)
         assert my_flags == ['-foo', '-I', f'/workspace/{SOURCE_ROOT}/foo/include']
 
         # anything in $source/bar should NOT get the include folder
@@ -26,5 +26,5 @@ class TestAddFlags(object):
             fpath=Path(f"/workspace/{SOURCE_ROOT}/bar/bar.c"),
             input_flags=my_flags,
             source_root=workspace / SOURCE_ROOT,
-            workspace=workspace)
+            project_workspace=workspace)
         assert my_flags == ['-foo']


### PR DESCRIPTION
A few small tidy ups from a long-lived branch which we're pulling into master:
 - Moved `by_type()` to utils
 - Renamed a few more variables and params from _workspace_ to _project_workspace_. Some of these changes had already been brought into master from that branch, this completes it. Motivation: it was sometimes confusing/ambiguous as there's the both the _fab_ workspace and the _project_ workspace.
 - Step is now abstract, rather that just the base for grab steps, which is more correct.
 - The `FindSourceFiles` step no longer creates the output folders. That's not its job and folders are now created elsewhere now.
 - Added our helper script to run all build configs, as we currently do this frequently as a manual test.