### PR TITLE
Misc logic changes 1

### DIFF
--- a/source/fab/artefacts.py
+++ b/source/fab/artefacts.py
@@ -14,7 +14,7 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Iterable, Union, Dict, List
 
-from fab.dep_tree import AnalysedFile
+from fab.dep_tree import AnalysedFile, filter_source_tree
 from fab.util import suffix_filter
 
 
@@ -119,19 +119,19 @@ class FilterBuildTree(ArtefactsGetter):
     Example::
 
         # The default source getter for the CompileFortran step.
-        DEFAULT_SOURCE_GETTER = FilterBuildTree(suffixes=['.f90'])
+        DEFAULT_SOURCE_GETTER = FilterBuildTree(suffix='.f90')
 
     """
-    def __init__(self, suffixes: Iterable[str], collection_name: str = 'build_tree'):
+    def __init__(self, suffix: Union[str, List[str]], collection_name: str = 'build_tree'):
         """
         Args:
             - suffixes: An iterable of suffixes
 
         """
         self.collection_name = collection_name
-        self.suffixes = suffixes
+        self.suffixes = [suffix] if isinstance(suffix, str) else suffix
 
     def __call__(self, artefact_store):
         super().__call__(artefact_store)
-        analysed_files: Iterable[AnalysedFile] = artefact_store[self.collection_name].values()
-        return list(filter(lambda af: af.fpath.suffix in self.suffixes, analysed_files))
+        source_tree: Dict[Path, AnalysedFile] = artefact_store[self.collection_name]
+        return filter_source_tree(source_tree=source_tree, suffixes=self.suffixes)

--- a/source/fab/build_config.py
+++ b/source/fab/build_config.py
@@ -106,8 +106,8 @@ class BuildConfig(object):
     def _init_logging(self):
         # add a file logger for our run
         log_file_handler = RotatingFileHandler(self.project_workspace / 'log.txt', backupCount=5, delay=True)
-        logger.root.addHandler(log_file_handler)
         log_file_handler.doRollover()
+        logging.getLogger('fab').addHandler(log_file_handler)
 
         logger.info(f"{datetime.now()}")
         if self.multiprocessing:
@@ -118,9 +118,10 @@ class BuildConfig(object):
 
     def _finalise_logging(self):
         # remove our file logger
-        log_file_handlers = list(by_type(logger.root.handlers, RotatingFileHandler))
+        fab_logger = logging.getLogger('fab')
+        log_file_handlers = list(by_type(fab_logger.handlers, RotatingFileHandler))
         assert len(log_file_handlers) == 1
-        logger.root.removeHandler(log_file_handlers[0])
+        fab_logger.removeHandler(log_file_handlers[0])
 
     def _finalise_metrics(self, start_time, steps_timer):
         send_metric('run', 'label', self.project_label)

--- a/source/fab/dep_tree.py
+++ b/source/fab/dep_tree.py
@@ -9,7 +9,7 @@ Classes and helper functions related to the dependency tree, as created by the a
 """
 import logging
 from pathlib import Path
-from typing import Set, Dict, List, Iterable
+from typing import Set, Dict, Iterable
 
 logger = logging.getLogger(__name__)
 

--- a/source/fab/steps/analyse.py
+++ b/source/fab/steps/analyse.py
@@ -99,36 +99,37 @@ class Analyse(Step):
 
         with TimerLogger("analysing files"):
             with self._new_analysis_file(unchanged) as csv_writer:
-                analysed_fortran, analysed_c = self._parse_files(changed, csv_writer)
-        all_analysed_files: Dict[Path, AnalysedFile] = {a.fpath: a for a in unchanged + analysed_fortran + analysed_c}
+                freshly_analysed_fortran, freshly_analysed_c = self._parse_files(changed, csv_writer)
+        source_tree: Dict[Path, AnalysedFile] = {
+            a.fpath: a for a in unchanged + freshly_analysed_fortran + freshly_analysed_c}
 
         # Make "external" symbol table
         with TimerLogger("creating symbol lookup"):
-            symbols: Dict[str, Path] = self._gen_symbol_table(all_analysed_files)
+            symbols: Dict[str, Path] = self._gen_symbol_table(source_tree)
 
         # turn symbol deps into file deps
         with TimerLogger("generating file dependencies from symbols"):
-            self._gen_file_deps(all_analysed_files, symbols)
+            self._gen_file_deps(source_tree, symbols)
 
         #  find the file dependencies for MO FCM's "DEPENDS ON:" commented file deps
         with TimerLogger("adding MO FCM 'DEPENDS ON:' file dependency comments"):
-            add_mo_commented_file_deps(analysed_fortran, analysed_c)
+            add_mo_commented_file_deps(source_tree)
 
-        logger.info(f"source tree size {len(all_analysed_files)}")
+        logger.info(f"source tree size {len(source_tree)}")
 
         # Target tree extraction - for building executables.
         if self.root_symbol:
             with TimerLogger("extracting target tree"):
-                build_tree = extract_sub_tree(all_analysed_files, symbols[self.root_symbol], verbose=False)
+                build_tree = extract_sub_tree(source_tree, symbols[self.root_symbol], verbose=False)
             logger.info(f"build tree size {len(build_tree)} (target '{symbols[self.root_symbol]}')")
         # When building library ".so" files, no target is needed.
         else:
             logger.info("no target specified, building everything")
-            build_tree = all_analysed_files
+            build_tree = source_tree
 
         # Recursively add any unreferenced dependencies
         # (a fortran routine called without a use statement).
-        self._add_unreferenced_deps(symbols, all_analysed_files, build_tree)
+        self._add_unreferenced_deps(symbols, source_tree, build_tree)
 
         validate_build_tree(build_tree)
 

--- a/source/fab/steps/compile_c.py
+++ b/source/fab/steps/compile_c.py
@@ -18,7 +18,7 @@ from fab.artefacts import ArtefactsGetter, FilterBuildTree
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_SOURCE_GETTER = FilterBuildTree(suffixes=['.c'])
+DEFAULT_SOURCE_GETTER = FilterBuildTree(suffix='.c')
 
 
 class CompileC(MpExeStep):

--- a/source/fab/steps/compile_fortran.py
+++ b/source/fab/steps/compile_fortran.py
@@ -20,7 +20,7 @@ from fab.artefacts import ArtefactsGetter, FilterBuildTree
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_SOURCE_GETTER = FilterBuildTree(suffixes=['.f90'])
+DEFAULT_SOURCE_GETTER = FilterBuildTree(suffix='.f90')
 
 
 class CompileFortran(MpExeStep):


### PR DESCRIPTION
A few small logic changes from a long-lived branch that we're bringing into master.
 - Allow `FilterBuildTree` to accept a single suffix as a string.
 - Log file handler now attached to fab logger instead of root.
 - Simplify params to `add_mo_commented_file_deps`, including new helper `filter_source_tree`.