### PR TITLE
Misc logic 2

### DIFF
--- a/source/fab/build_config.py
+++ b/source/fab/build_config.py
@@ -42,7 +42,7 @@ class BuildConfig(object):
         The number of cores to use for multiprocessing operations. Defaults to the number of available cores - 1.
     :param bool reuse_artefacts:
         A flag to avoid reprocessing artefacts a second time.
-        Currently unsophisticated, the existence of an output file means it doesn't need to be reprocessed.
+        WARNING: Currently unsophisticated, the mere existence of an output file means it won't be reprocessed.
         The logic behind flag will be improved in the future.
 
     """

--- a/source/fab/steps/compile_c.py
+++ b/source/fab/steps/compile_c.py
@@ -8,6 +8,7 @@ C file compilation.
 
 """
 import logging
+import os
 from typing import List
 
 from fab.metrics import send_metric
@@ -26,8 +27,9 @@ DEFAULT_SOURCE_GETTER = FilterBuildTree(suffixes=['.c'])
 class CompileC(MpExeStep):
 
     # todo: tell the compiler (and other steps) which artefact name to create?
-    def __init__(self, compiler: str = 'gcc', common_flags: List[str] = None, path_flags: List = None,
+    def __init__(self, compiler: str = None, common_flags: List[str] = None, path_flags: List = None,
                  source: ArtefactsGetter = None, name="compile c"):
+        compiler = compiler or os.getenv('CC', 'gcc -c')
         super().__init__(exe=compiler, common_flags=common_flags, path_flags=path_flags, name=name)
         self.source_getter = source or DEFAULT_SOURCE_GETTER
 

--- a/source/fab/steps/compile_fortran.py
+++ b/source/fab/steps/compile_fortran.py
@@ -8,6 +8,7 @@ Fortran file compilation.
 
 """
 import logging
+import os
 from pathlib import Path
 from typing import List, Set, Dict
 
@@ -25,8 +26,9 @@ DEFAULT_SOURCE_GETTER = FilterBuildTree(suffixes=['.f90'])
 
 class CompileFortran(MpExeStep):
 
-    def __init__(self, compiler: str, common_flags: List[str] = None, path_flags: List = None,
+    def __init__(self, compiler: str = None, common_flags: List[str] = None, path_flags: List = None,
                  source: ArtefactsGetter = None, name='compile fortran'):
+        compiler = compiler or os.getenv('FC', 'gfortran -c')
         super().__init__(exe=compiler, common_flags=common_flags, path_flags=path_flags, name=name)
         self.source_getter = source or DEFAULT_SOURCE_GETTER
 

--- a/source/fab/steps/compile_fortran.py
+++ b/source/fab/steps/compile_fortran.py
@@ -115,27 +115,31 @@ class CompileFortran(MpExeStep):
 
         return compile_next
 
+    # todo: identical to the c version - make a super class
     def compile_file(self, analysed_file: AnalysedFile):
-        with Timer() as timer:
-            command = [self.exe]
-            command.extend(self.flags.flags_for_path(
-                path=analysed_file.fpath,
-                source_root=self._config.source_root,
-                workspace=self._config.project_workspace))
-            command.append(str(analysed_file.fpath))
+        output_fpath = analysed_file.fpath.with_suffix('.o')
 
-            output_fpath = analysed_file.fpath.with_suffix('.o')
-            if self._config.reuse_artefacts and output_fpath.exists():
-                log_or_dot(logger, f'Compiler skipping: {output_fpath}')
-                return CompiledFile(analysed_file, output_fpath)
+        # already compiled?
+        if self._config.reuse_artefacts and output_fpath.exists():
+            log_or_dot(logger, f'CompileFortran skipping: {analysed_file.fpath}')
+        else:
+            with Timer() as timer:
+                output_fpath.parent.mkdir(parents=True, exist_ok=True)
 
-            command.extend(['-o', str(output_fpath)])
+                command = self.exe.split()
+                command.extend(self.flags.flags_for_path(
+                    path=analysed_file.fpath,
+                    source_root=self._config.source_root,
+                    workspace=self._config.project_workspace))
+                command.append(str(analysed_file.fpath))
+                command.extend(['-o', str(output_fpath)])
 
-            log_or_dot(logger, 'Compiler running command: ' + ' '.join(command))
-            try:
-                run_command(command)
-            except Exception as err:
-                return Exception("Error calling compiler:", err)
+                log_or_dot(logger, 'CompileFortran running command: ' + ' '.join(command))
+                try:
+                    run_command(command)
+                except Exception as err:
+                    return Exception("Error calling compiler:", err)
 
-        send_metric(self.name, str(analysed_file.fpath), timer.taken)
+            send_metric(self.name, str(analysed_file.fpath), timer.taken)
+
         return CompiledFile(analysed_file, output_fpath)

--- a/source/fab/steps/link_exe.py
+++ b/source/fab/steps/link_exe.py
@@ -54,7 +54,7 @@ class LinkExe(Step):
 
         compiled_files = self.source_getter(artefact_store)
 
-        command = [self.linker]
+        command = self.linker.split()
         command.extend(['-o', Template(self.output_fpath).substitute(
             output=str(config.project_workspace / BUILD_OUTPUT))])
         command.extend([str(a.output_fpath) for a in compiled_files])

--- a/source/fab/steps/preprocess.py
+++ b/source/fab/steps/preprocess.py
@@ -8,6 +8,7 @@ Fortran and C Preprocessing.
 
 """
 import logging
+import os
 from pathlib import Path
 from typing import List
 
@@ -113,12 +114,12 @@ class PreProcessor(MpExeStep):
         return output_fpath
 
 
-def fortran_preprocessor(preprocessor='fpp', source=None,
+def fortran_preprocessor(preprocessor=None, source=None,
                          output_collection='preprocessed_fortran', output_suffix='.f90',
                          name='preprocess fortran', **pp_kwds):
 
     return PreProcessor(
-        preprocessor=preprocessor,
+        preprocessor=preprocessor or os.getenv('FPP', 'fpp -P'),
         source=source or SuffixFilter('all_source', '.F90'),
         output_collection=output_collection,
         output_suffix=output_suffix,
@@ -127,12 +128,12 @@ def fortran_preprocessor(preprocessor='fpp', source=None,
     )
 
 
-def c_preprocessor(preprocessor='cpp', source=None,
+def c_preprocessor(preprocessor=None, source=None,
                    output_collection='preprocessed_c', output_suffix='.c',
                    name='preprocess c', **pp_kwds):
 
     return PreProcessor(
-        preprocessor=preprocessor,
+        preprocessor=preprocessor or os.getenv('CPP', 'cpp -traditional-cpp -P'),
         source=source or SuffixFilter('all_source', '.c'),
         output_collection=output_collection,
         output_suffix=output_suffix,

--- a/source/fab/steps/root_inc_files.py
+++ b/source/fab/steps/root_inc_files.py
@@ -14,7 +14,6 @@ import logging
 import shutil
 import warnings
 from pathlib import Path
-from typing import Optional
 
 from fab.constants import BUILD_OUTPUT
 from fab.steps import Step
@@ -25,10 +24,8 @@ logger = logging.getLogger(__name__)
 
 class RootIncFiles(Step):
 
-    def __init__(self, source_root=None, build_output: Optional[Path] = None, name="root inc files"):
+    def __init__(self, name="root inc files"):
         super().__init__(name)
-        self.source_root = source_root
-        self.build_output = build_output
 
     def run(self, artefact_store, config):
         """
@@ -40,8 +37,10 @@ class RootIncFiles(Step):
         """
         super().run(artefact_store, config)
 
-        source_root = self.source_root or config.source_root
-        build_output = self.build_output or source_root.parent / BUILD_OUTPUT
+        # todo: make the build output path a getter calculated in the config?
+        build_output: Path = config.source_root.parent / BUILD_OUTPUT
+        if not build_output.exists():
+            build_output.mkdir(parents=True, exist_ok=True)
 
         warnings.warn("RootIncFiles is deprecated as .inc files are due to be removed.", DeprecationWarning)
 
@@ -50,7 +49,7 @@ class RootIncFiles(Step):
         for fpath in suffix_filter(artefact_store["all_source"], [".inc"]):
 
             # don't copy from the output root to the output root!
-            # (i.e ancillary files from a previous run)
+            # this is currently unlikely to happen but did in the past, and caused problems.
             if fpath.parent == build_output:
                 continue
 


### PR DESCRIPTION
From a long-lived branch:
- Tidied and made consistent the artefact handlers in preprocessing and compiling steps.
- Consistent behaviour for default preprocessors and compilers.
- Remove config requirements for `RootIncFiles` class.