### PR TITLE
fix call analysis for lfric method calls

### DIFF
--- a/source/fab/tasks/fortran.py
+++ b/source/fab/tasks/fortran.py
@@ -104,7 +104,8 @@ class FortranAnalyser(object):
 
                 elif obj_type == Call_Stmt:
                     called_name = _typed_child(obj, Name)
-                    analysed_file.add_symbol_dep(called_name.string)
+                    if called_name:
+                        analysed_file.add_symbol_dep(called_name.string)
 
                 elif obj_type == Program_Stmt:
                     analysed_file.add_symbol_def(str(obj.get_name()))


### PR DESCRIPTION
The new call analysis code didn't work with `%` method calls.

It wasn't spotted because we only checked some of the run configs. The work we're currently doing on system tests should help avoid this class of problem in the future.