### PR TITLE
Fortran prebuild concept

### DIFF
--- a/run_configs/jules/build_jules.py
+++ b/run_configs/jules/build_jules.py
@@ -8,13 +8,15 @@ import logging
 import os
 from argparse import ArgumentParser
 
+from fab.constants import PREBUILD
+
 from fab.steps.archive_objects import ArchiveObjects
 
 from fab.build_config import BuildConfig
 from fab.steps.analyse import Analyse
 from fab.steps.compile_c import CompileC
 from fab.steps.compile_fortran import CompileFortran
-from fab.steps.grab import GrabFcm
+from fab.steps.grab import GrabFcm, GrabPreBuild
 from fab.steps.link_exe import LinkExe
 from fab.steps.preprocess import c_preprocessor, fortran_preprocessor
 from fab.steps.root_inc_files import RootIncFiles
@@ -44,6 +46,9 @@ def jules_config(revision=None, two_stage=False, opt='Og'):
 
         GrabFcm(src='fcm:jules.xm_tr/src', revision=revision, dst='src'),
         GrabFcm(src='fcm:jules.xm_tr/utils', revision=revision, dst='utils'),
+        
+        # Copy another pre-build folder into our own.
+        GrabPreBuild(path=f'/home/ho6/dbrown/fab_workspace/{config.project_label}/{PREBUILD}', allow_fail=True),
 
         FindSourceFiles(path_filters=[
             Exclude('src/control/um/'),

--- a/run_configs/jules/build_jules.py
+++ b/run_configs/jules/build_jules.py
@@ -48,7 +48,8 @@ def jules_config(revision=None, two_stage=False, opt='Og'):
         GrabFcm(src='fcm:jules.xm_tr/utils', revision=revision, dst='utils'),
         
         # Copy another pre-build folder into our own.
-        GrabPreBuild(path=f'/home/ho6/dbrown/fab_workspace/{config.project_label}/{PREBUILD}', allow_fail=True),
+        # GrabPreBuild(path=f'/home/ho6/dbrown/fab_workspace/{config.project_label}/{PREBUILD}', allow_fail=True),
+        GrabPreBuild(path=f'/home/h02/bblay/temp_prebuild', allow_fail=True),
 
         FindSourceFiles(path_filters=[
             Exclude('src/control/um/'),

--- a/source/fab/build_config.py
+++ b/source/fab/build_config.py
@@ -18,7 +18,7 @@ from pathlib import Path
 from string import Template
 from typing import List, Optional, Dict, Any
 
-from fab.constants import BUILD_OUTPUT, SOURCE_ROOT
+from fab.constants import BUILD_OUTPUT, SOURCE_ROOT, ARTEFACT_REPOSITORY_FOLDER
 from fab.metrics import send_metric, init_metrics, stop_metrics, metrics_summary
 from fab.steps import Step
 from fab.util import TimerLogger, by_type
@@ -69,6 +69,7 @@ class BuildConfig(object):
                 logger.info(f"FAB_WORKSPACE not set, defaulting to {fab_workspace}")
         logger.info(f"\nfab workspace is {fab_workspace}")
 
+        self.fab_workspace = fab_workspace
         self.project_workspace = fab_workspace / (project_label.replace(' ', '-'))
         self.metrics_folder = self.project_workspace / 'metrics' / self.project_label.replace(' ', '_', -1)
 
@@ -95,6 +96,10 @@ class BuildConfig(object):
     @property
     def build_output(self):
         return self.project_workspace / BUILD_OUTPUT
+
+    @property
+    def artefact_repository_folder(self):
+        return self.fab_workspace / ARTEFACT_REPOSITORY_FOLDER
 
     def run(self):
         """

--- a/source/fab/constants.py
+++ b/source/fab/constants.py
@@ -16,6 +16,8 @@ Some constants to help keep things tidy and manageable.
 SOURCE_ROOT = "source"
 BUILD_OUTPUT = "build_output"
 
+ARTEFACT_REPOSITORY_FOLDER = '_artefact_repository'
+
 # names of artefact collections
 PROJECT_SOURCE_TREE = 'project source tree'
 PRAGMAD_C = 'pragmad_c'

--- a/source/fab/constants.py
+++ b/source/fab/constants.py
@@ -16,7 +16,8 @@ Some constants to help keep things tidy and manageable.
 SOURCE_ROOT = "source"
 BUILD_OUTPUT = "build_output"
 
-ARTEFACT_REPOSITORY_FOLDER = '_artefact_repository'
+# prebuild folder name
+PREBUILD = '_prebuild'
 
 # names of artefact collections
 PROJECT_SOURCE_TREE = 'project source tree'

--- a/source/fab/dep_tree.py
+++ b/source/fab/dep_tree.py
@@ -92,12 +92,12 @@ class AnalysedFile(object):
         assert name and len(name)
         self.file_deps.add(name)
 
-    @property
-    def compiled_path(self):
-        """The compiled_path property defines where the compiler is expected to put the object file."""
-        # This might not seem relevant to the concept of an AnalysedFile. However, it is required in several places
-        # throughout the codebase, so we've DRY'd it here.
-        return self.fpath.with_suffix('.o')
+    # @property
+    # def compiled_path(self):
+    #     """The compiled_path property defines where the compiler is expected to put the object file."""
+    #     # This might not seem relevant to the concept of an AnalysedFile. However, it is required in several places
+    #     # throughout the codebase, so we've DRY'd it here.
+    #     return self.fpath.with_suffix('.o')
 
     @property
     def mod_filenames(self):

--- a/source/fab/dep_tree.py
+++ b/source/fab/dep_tree.py
@@ -92,13 +92,6 @@ class AnalysedFile(object):
         assert name and len(name)
         self.file_deps.add(name)
 
-    # @property
-    # def compiled_path(self):
-    #     """The compiled_path property defines where the compiler is expected to put the object file."""
-    #     # This might not seem relevant to the concept of an AnalysedFile. However, it is required in several places
-    #     # throughout the codebase, so we've DRY'd it here.
-    #     return self.fpath.with_suffix('.o')
-
     @property
     def mod_filenames(self):
         """The mod_filenames property defines which module files are expected to be created (but not where)."""

--- a/source/fab/steps/compile_fortran.py
+++ b/source/fab/steps/compile_fortran.py
@@ -7,13 +7,12 @@
 Fortran file compilation.
 
 """
-import csv
 import logging
 import os
 import zlib
 from collections import defaultdict
 from pathlib import Path
-from typing import List, Set, Dict, Optional
+from typing import List, Set, Dict
 
 from fab.constants import OBJECT_FILES
 
@@ -80,7 +79,6 @@ class CompileFortran(MpExeStep):
 
         # runtime
         self._stage = None
-        # self._last_compiles: Dict[Path, CompiledFile] = {}
         self._mod_hashes: Dict[str, int] = {}
 
     def run(self, artefact_store, config):
@@ -98,9 +96,6 @@ class CompileFortran(MpExeStep):
 
         """
         super().run(artefact_store, config)
-
-        # read csv of last compile states
-        # self._last_compiles = self.read_compile_result(config)
 
         # get all the source to compile, for all build trees, into one big lump
         build_lists: Dict[str, List] = self.source_getter(artefact_store)
@@ -129,8 +124,6 @@ class CompileFortran(MpExeStep):
             check_for_errors(results_this_pass, caller_label=self.name)
             compiled_this_pass = list(by_type(results_this_pass, CompiledFile))
             logger.info(f"stage 2 compiled {len(compiled_this_pass)} files")
-
-        # self.write_compile_result(compiled, config)
 
         self.store_artefacts(compiled, build_lists, artefact_store)
 
@@ -253,7 +246,6 @@ class CompileFortran(MpExeStep):
 
     def compile_file(self, analysed_file, flags, output_fpath):
         with Timer() as timer:
-            # output_fpath = analysed_file.compiled_path
             output_fpath.parent.mkdir(parents=True, exist_ok=True)
 
             # tool
@@ -278,34 +270,3 @@ class CompileFortran(MpExeStep):
             group=metric_name,
             name=str(analysed_file.fpath),
             value={'time_taken': timer.taken, 'start': timer.start})
-
-    # def write_compile_result(self, compiled: Dict[Path, CompiledFile], config):
-    #     """
-    #     Write the compilation results to csv.
-    #
-    #     """
-    #     compilation_progress_file = open(config.build_output / FORTRAN_COMPILED_CSV, "wt")
-    #     dict_writer = csv.DictWriter(compilation_progress_file, fieldnames=CompiledFile.field_names())
-    #     dict_writer.writeheader()
-    #
-    #     for cf in compiled.values():
-    #         dict_writer.writerow(cf.to_str_dict())
-
-    # def read_compile_result(self, config) -> Dict[Path, CompiledFile]:
-    #     """
-    #     Read the results of the last compile run.
-    #
-    #     """
-    #     with TimerLogger('loading compile results'):
-    #         prev_results: Dict[Path, CompiledFile] = dict()
-    #         try:
-    #             with open(config.build_output / FORTRAN_COMPILED_CSV, "rt") as csv_file:
-    #                 dict_reader = csv.DictReader(csv_file)
-    #                 for row in dict_reader:
-    #                     compiled_file = CompiledFile.from_str_dict(row)
-    #                     prev_results[compiled_file.input_fpath] = compiled_file
-    #         except FileNotFoundError:
-    #             pass
-    #         logger.info(f"loaded {len(prev_results)} compile results")
-    #
-    #     return prev_results

--- a/source/fab/steps/compile_fortran.py
+++ b/source/fab/steps/compile_fortran.py
@@ -215,7 +215,7 @@ class CompileFortran(MpExeStep):
 
         # the object filename includes the combo hash, e.g /foo/bar.f90 --> /foo/bar.12345.o
         p = analysed_file.fpath
-        object_filename = self._config.artefact_repository_folder / f'{p.stem}.{combo_hash:x}.o'
+        object_filename = self._config.prebuild_folder / f'{p.stem}.{combo_hash:x}.o'
 
         # are the module files we define still there?
         mods_missing = False

--- a/source/fab/steps/grab.py
+++ b/source/fab/steps/grab.py
@@ -7,6 +7,7 @@
 Build steps for pulling source code from remote repos and local folders.
 
 """
+import logging
 import os
 from abc import ABC, abstractmethod
 from pathlib import Path
@@ -22,7 +23,10 @@ from fab.steps import Step
 from fab.util import run_command
 
 
-class GrabBase(Step, ABC):
+logger = logging.getLogger(__name__)
+
+
+class GrabSourceBase(Step, ABC):
     """
     Base class for grab steps. All grab steps require a source and a folder in which to put it.
 
@@ -61,7 +65,7 @@ class GrabBase(Step, ABC):
             config.source_root.mkdir(parents=True, exist_ok=True)
 
 
-class GrabFolder(GrabBase):
+class GrabFolder(GrabSourceBase):
     """
     Copy a source folder to the project workspace.
 
@@ -82,20 +86,14 @@ class GrabFolder(GrabBase):
     def run(self, artefact_store: Dict, config):
         super().run(artefact_store, config)
 
-        # we want the source folder to end with a / for rsync because we don't want it to create a sub folder
-        src = os.path.expanduser(self.src)
-        if not src.endswith('/'):
-            src += '/'
-
         dst: Path = config.source_root / self.dst_label
         dst.mkdir(parents=True, exist_ok=True)
 
-        command = ['rsync', '-ruq', src, str(dst)]
-        run_command(command)
+        call_rsync(src=self.src, dst=dst)
 
 
 # todo: checkout operation might be quicker for some use cases, add an option for this?
-class GrabFcm(GrabBase):
+class GrabFcm(GrabSourceBase):
     """
     Grab an FCM repo folder to the project workspace.
 
@@ -127,7 +125,7 @@ class GrabFcm(GrabBase):
 
 
 if svn:
-    class GrabSvn(GrabBase):
+    class GrabSvn(GrabSourceBase):
         """
         Grab an SVN repo folder to the project workspace.
 
@@ -157,3 +155,35 @@ if svn:
 
             r = remote.RemoteClient(self.src)
             r.export(str(config.source_root / self.dst_label), revision=self.revision, force=True)
+
+
+class GrabPreBuild(Step):
+    """
+    Copy the contents of another pre-build folder into our own.
+
+    """
+    def __init__(self, path, objects=True, allow_fail=False):
+        super().__init__(name=f'prebuild {path}')
+        self.src = path
+        self.objects = objects
+        self.allow_fail = allow_fail
+    
+    def run(self, artefact_store: Dict, config):
+        dst = config.prebuild_folder
+        try:
+            call_rsync(src=self.src, dst=dst)
+        except RuntimeError as err:
+            msg = f"could not grab pre-build '{self.src}': {err}"
+            if not self.allow_fail:
+                raise RuntimeError(msg)
+            logger.warning(msg)
+
+
+def call_rsync(src: Union[str, Path], dst: Union[str, Path]):
+    # we want the source folder to end with a / for rsync because we don't want it to create a sub folder
+    src = os.path.expanduser(str(src))
+    if not src.endswith('/'):
+        src += '/'
+
+    command = ['rsync', '-ruq', src, str(dst)]
+    run_command(command)

--- a/source/fab/steps/grab.py
+++ b/source/fab/steps/grab.py
@@ -163,7 +163,7 @@ class GrabPreBuild(Step):
 
     """
     def __init__(self, path, objects=True, allow_fail=False):
-        super().__init__(name=f'prebuild {path}')
+        super().__init__(name=f'GrabPreBuild {path}')
         self.src = path
         self.objects = objects
         self.allow_fail = allow_fail
@@ -171,7 +171,14 @@ class GrabPreBuild(Step):
     def run(self, artefact_store: Dict, config):
         dst = config.prebuild_folder
         try:
-            call_rsync(src=self.src, dst=dst)
+            res = call_rsync(src=self.src, dst=dst)
+
+            # logger.info(res.decode())
+            # log the number of files transferred
+
+            to_print = [line for line in res.decode().split('\n') if 'Number of' in line]
+            logger.info('\n'.join(to_print))
+
         except RuntimeError as err:
             msg = f"could not grab pre-build '{self.src}': {err}"
             if not self.allow_fail:
@@ -185,5 +192,5 @@ def call_rsync(src: Union[str, Path], dst: Union[str, Path]):
     if not src.endswith('/'):
         src += '/'
 
-    command = ['rsync', '-times', '-ruq', src, str(dst)]
-    run_command(command)
+    command = ['rsync', '-times', '--stats', '-ru', src, str(dst)]
+    return run_command(command)

--- a/source/fab/steps/grab.py
+++ b/source/fab/steps/grab.py
@@ -185,5 +185,5 @@ def call_rsync(src: Union[str, Path], dst: Union[str, Path]):
     if not src.endswith('/'):
         src += '/'
 
-    command = ['rsync', '-ruq', src, str(dst)]
+    command = ['rsync', '-times', '-ruq', src, str(dst)]
     run_command(command)

--- a/source/fab/util.py
+++ b/source/fab/util.py
@@ -254,6 +254,8 @@ def run_command(command, env=None):
     if res.returncode != 0:
         raise RuntimeError(f"Command failed:\n{command}\n{res.stderr.decode()}")
 
+    return res.stdout
+
 
 def suffix_filter(fpaths: Iterable[Path], suffixes: Iterable[str]):
     """


### PR DESCRIPTION
A simple Fortran pre-build solution, somewhere between a code-sketch and a proposal.
 - The user can copy other users' pre-built object files onto their machine without worrying about overwriting something they need.
 - The location of the object files is _above_ the project workspace, in the _Fab_ workspace, and is also flat.
 - A further improvement, again seemingly simple, would be to allow the user to merely point to other users' workspaces, from which Fab will only copy the files it needs.
 - There may be file proliferation over time, which is trivial to solve and ignored here.