### PR TITLE
Compiler version in prebuild checksums

### DIFF
--- a/source/fab/steps/compile_fortran.py
+++ b/source/fab/steps/compile_fortran.py
@@ -65,13 +65,16 @@ class CompileFortran(Step):
         compiler = compiler or os.getenv('FC', 'gfortran -c')
         common_flags = common_flags or []
         env_flags = os.getenv('FFLAGS', '').split()
-        self.exe = compiler or os.getenv('FC', 'gfortran -c')
+        self.exe: str = compiler or os.getenv('FC', 'gfortran -c')  # type: ignore
         self.flags = FlagsConfig(
             common_flags=remove_minus_J(common_flags + env_flags, verbose=True),
             path_flags=path_flags)
         self.source_getter = source or DEFAULT_SOURCE_GETTER
 
         self.two_stage_flag = two_stage_flag
+
+        # not ideal to do work in a constructor...
+        self.compiler_version = _get_compiler_version(self.exe.split()[0])
 
         # runtime
         self._stage = None
@@ -252,7 +255,8 @@ class CompileFortran(Step):
                 analysed_file.file_hash,
                 flags_checksum(flags),
                 sum(mod_deps_hashes.values()),
-                zlib.crc32(self.exe.encode())
+                zlib.crc32(self.exe.encode()),
+                zlib.crc32(self.compiler_version.encode()),
             ])
         except TypeError:
             raise ValueError("could not generate combo hash for object file")
@@ -263,7 +267,8 @@ class CompileFortran(Step):
         try:
             mod_combo_hash = sum([
                 analysed_file.file_hash,
-                zlib.crc32(self.exe.encode())
+                zlib.crc32(self.exe.encode()),
+                zlib.crc32(self.compiler_version.encode()),
             ])
         except TypeError:
             raise ValueError("could not generate combo hash for mod files")
@@ -305,3 +310,44 @@ class CompileFortran(Step):
             group=metric_name,
             name=str(analysed_file.fpath),
             value={'time_taken': timer.taken, 'start': timer.start})
+
+
+# todo: add more compilers and test with more versions of compilers
+def _get_compiler_version(compiler: str) -> str:
+    """
+    Try to get the version of the given compiler.
+
+    Expects a version in a certain part of the --version output,
+    which must adhere to the n.n.n format, with at least 2 parts.
+
+    Returns a version string, e.g '6.10.1', or empty string.
+
+    """
+    try:
+        res = run_command([compiler, '--version'])
+    except FileNotFoundError:
+        raise ValueError(f'Compiler not found: {compiler}')
+    except RuntimeError as err:
+        logger.warning(f"Error asking for version of compiler '{compiler}': {err}")
+        return ''
+
+    # Pull the version string from the command output.
+    # All the versions of gfortran and ifort we've tried follow the same pattern, it's after a ")".
+    try:
+        version = res.split(')')[1].split()[0]
+    except IndexError:
+        logger.warning(f"Unexpected version response from compiler '{compiler}': {res}")
+        return ''
+
+    # expect major.minor[.patch, ...]
+    # validate - this may be overkill
+    split = version.split('.')
+    if len(split) < 2:
+        logger.warning(f"unhandled compiler version format for compiler '{compiler}' is not <n.n[.n, ...]>: {version}")
+        return ''
+
+    # todo: do we care if the parts are integers? Not all will be, but perhaps major and minor?
+
+    logger.info(f'Found compiler version for {compiler} = {version}')
+
+    return version

--- a/tests/unit_tests/steps/test_compile_fortran.py
+++ b/tests/unit_tests/steps/test_compile_fortran.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from textwrap import dedent
 from unittest import mock
 from unittest.mock import call
 
@@ -8,13 +9,15 @@ from fab.build_config import BuildConfig
 from fab.constants import BUILD_TREES, OBJECT_FILES
 
 from fab.dep_tree import AnalysedFile
-from fab.steps.compile_fortran import CompileFortran
+from fab.steps.compile_fortran import CompileFortran, _get_compiler_version
 from fab.util import CompiledFile
 
 
 @pytest.fixture()
 def compiler():
-    return CompileFortran(compiler="foo_cc")
+    with mock.patch('fab.steps.compile_fortran._get_compiler_version', return_value='1.2.3'):
+        compiler = CompileFortran(compiler="foo_cc")
+    return compiler
 
 
 @pytest.fixture
@@ -110,7 +113,9 @@ class Test_store_artefacts(object):
 class Test_process_file(object):
 
     def content(self, flags=None):
-        compiler = CompileFortran(compiler="foo_cc")
+
+        with mock.patch('fab.steps.compile_fortran._get_compiler_version', return_value='1.2.3'):
+            compiler = CompileFortran(compiler="foo_cc")
 
         flags = flags or ['flag1', 'flag2']
         compiler.flags = mock.Mock()
@@ -125,12 +130,16 @@ class Test_process_file(object):
         analysed_file.add_module_def('mod_def_1')
         analysed_file.add_module_def('mod_def_2')
 
-        expect_object_fpath = Path('/fab/proj/build_output/_prebuild/foofile.161554537.o')
+        obj_combo_hash = '1eb0c2d19'
+        mods_combo_hash = '1747a9a0f'
 
-        return compiler, flags, analysed_file, expect_object_fpath
+        return compiler, flags, analysed_file, obj_combo_hash, mods_combo_hash
 
-    def ensure_mods_stored(self, mock_copy, mods_combo_hash='eac3b22d'):
-        # make sure the newly created mod files were copied TO the prebuilds folder
+    # Developer's note: If the "mods combo hash" changes you'll get an unhelpful message from pytest.
+    # It'll come from this function but pytest won't tell you that.
+    # You'll have to set a breakpoint here to see the changed hash in calls to mock_copy.
+    def ensure_mods_stored(self, mock_copy, mods_combo_hash):
+        # Make sure the newly created mod files were copied TO the prebuilds folder.
         mock_copy.assert_has_calls(
             calls=[
                 call(Path('/fab/proj/build_output/mod_def_1.mod'),
@@ -141,7 +150,7 @@ class Test_process_file(object):
             any_order=True,
         )
 
-    def ensure_mods_restored(self, mock_copy, mods_combo_hash='eac3b22d'):
+    def ensure_mods_restored(self, mock_copy, mods_combo_hash):
         # make sure previously built mod files were copied FROM the prebuilds folder
         mock_copy.assert_has_calls(
             calls=[
@@ -155,120 +164,279 @@ class Test_process_file(object):
 
     def test_without_prebuild(self):
         # call compile_file() and return a CompiledFile
-        compiler, flags, analysed_file, expect_object_fpath = self.content()
+        compiler, flags, analysed_file, obj_combo_hash, mods_combo_hash = self.content()
 
         with mock.patch('pathlib.Path.exists', return_value=False):  # no output files exist
             with mock.patch('fab.steps.compile_fortran.CompileFortran.compile_file') as mock_compile_file:
                 with mock.patch('shutil.copy2') as mock_copy:
                     res = compiler.process_file(analysed_file)
 
+        expect_object_fpath = Path(f'/fab/proj/build_output/_prebuild/foofile.{obj_combo_hash}.o')
         assert res == CompiledFile(input_fpath=analysed_file.fpath, output_fpath=expect_object_fpath)
         mock_compile_file.assert_called_once_with(analysed_file, flags, output_fpath=expect_object_fpath)
-        self.ensure_mods_stored(mock_copy)
+        self.ensure_mods_stored(mock_copy, mods_combo_hash)
 
     def test_with_prebuild(self):
         # If the mods and obj are prebuilt, don't compile.
-        compiler, flags, analysed_file, expect_object_fpath = self.content()
+        compiler, flags, analysed_file, obj_combo_hash, mods_combo_hash = self.content()
 
         with mock.patch('pathlib.Path.exists', return_value=True):  # mod def files and obj file all exist
             with mock.patch('fab.steps.compile_fortran.CompileFortran.compile_file') as mock_compile_file:
                 with mock.patch('shutil.copy2') as mock_copy:
                     res = compiler.process_file(analysed_file)
 
+        expect_object_fpath = Path(f'/fab/proj/build_output/_prebuild/foofile.{obj_combo_hash}.o')
         assert res == CompiledFile(input_fpath=analysed_file.fpath, output_fpath=expect_object_fpath)
         mock_compile_file.assert_not_called()
-        self.ensure_mods_restored(mock_copy)
+        self.ensure_mods_restored(mock_copy, mods_combo_hash)
 
     def test_file_hash(self):
-        # changing the source hash must change the combo hash for the mods and obj
-        compiler, flags, analysed_file, expect_object_fpath = self.content()
+        # Changing the source hash must change the combo hash for the mods and obj.
+        # Note: This test adds 1 to the analysed files hash. We're using checksums so
+        #       the resulting object file and mod file combo hashes can be expected to increase by 1 too.
+        compiler, flags, analysed_file, obj_combo_hash, mods_combo_hash = self.content()
+
         analysed_file.file_hash += 1
-        expect_object_fpath = Path('/fab/proj/build_output/_prebuild/foofile.161554538.o')  # object combo hash += 1
+        obj_combo_hash = f'{int(obj_combo_hash, 16) + 1:x}'
+        mods_combo_hash = f'{int(mods_combo_hash, 16) + 1:x}'
 
         with mock.patch('pathlib.Path.exists', side_effect=[True, True, False]):  # mod files exist, obj file doesn't
             with mock.patch('fab.steps.compile_fortran.CompileFortran.compile_file') as mock_compile_file:
                 with mock.patch('shutil.copy2') as mock_copy:
                     res = compiler.process_file(analysed_file)
 
+        expect_object_fpath = Path(f'/fab/proj/build_output/_prebuild/foofile.{obj_combo_hash}.o')
         assert res == CompiledFile(input_fpath=analysed_file.fpath, output_fpath=expect_object_fpath)
         mock_compile_file.assert_called_once_with(analysed_file, flags, output_fpath=expect_object_fpath)
-        self.ensure_mods_stored(mock_copy, mods_combo_hash='eac3b22e')  # mods combo hash += 1
+        self.ensure_mods_stored(mock_copy, mods_combo_hash)
 
     def test_flags_hash(self):
         # changing the flags must change the object combo hash, but not the mods combo hash
-        compiler, flags, analysed_file, expect_object_fpath = self.content(flags=['flag1', 'flag3'])
-        expect_object_fpath = Path('/fab/proj/build_output/_prebuild/foofile.16217ab0c.o')
+        compiler, flags, analysed_file, _, mods_combo_hash = self.content(flags=['flag1', 'flag3'])
+        obj_combo_hash = '1ebce92ee'
 
         with mock.patch('pathlib.Path.exists', side_effect=[True, True, False]):  # mod files exist, obj file doesn't
             with mock.patch('fab.steps.compile_fortran.CompileFortran.compile_file') as mock_compile_file:
                 with mock.patch('shutil.copy2') as mock_copy:
                     res = compiler.process_file(analysed_file)
 
+        expect_object_fpath = Path(f'/fab/proj/build_output/_prebuild/foofile.{obj_combo_hash}.o')
         assert res == CompiledFile(input_fpath=analysed_file.fpath, output_fpath=expect_object_fpath)
         mock_compile_file.assert_called_once_with(analysed_file, flags, output_fpath=expect_object_fpath)
-        self.ensure_mods_stored(mock_copy)
+        self.ensure_mods_stored(mock_copy, mods_combo_hash)
 
     def test_deps_hash(self):
-        # changing the checksums of any module dependency must change the object combo hash, but not the mods combo hash
-        compiler, flags, analysed_file, expect_object_fpath = self.content()
+        # Changing the checksums of any mod dependency must change the object combo hash but not the mods combo hash.
+        # Note the difference between mods we depend on and mods we define.
+        # The mods we define are not affected by the mods we depend on.
+        compiler, flags, analysed_file, obj_combo_hash, mods_combo_hash = self.content()
+
         compiler._mod_hashes['mod_dep_1'] += 1
-        expect_object_fpath = Path('/fab/proj/build_output/_prebuild/foofile.161554538.o')  # hash += 1
+        obj_combo_hash = f'{int(obj_combo_hash, 16) + 1:x}'
 
         with mock.patch('pathlib.Path.exists', side_effect=[True, True, False]):  # mod files exist, obj file doesn't
             with mock.patch('fab.steps.compile_fortran.CompileFortran.compile_file') as mock_compile_file:
                 with mock.patch('shutil.copy2') as mock_copy:
                     res = compiler.process_file(analysed_file)
 
+        expect_object_fpath = Path(f'/fab/proj/build_output/_prebuild/foofile.{obj_combo_hash}.o')
         mock_compile_file.assert_called_once_with(analysed_file, flags, output_fpath=expect_object_fpath)
         assert res == CompiledFile(input_fpath=analysed_file.fpath, output_fpath=expect_object_fpath)
-        self.ensure_mods_stored(mock_copy)
+        self.ensure_mods_stored(mock_copy, mods_combo_hash)
 
     def test_compiler_hash(self):
         # changing the compiler must change the combo hash for the mods and obj
-        compiler, flags, analysed_file, expect_object_fpath = self.content()
+        compiler, flags, analysed_file, _, _ = self.content()
+
         compiler.exe = 'bar_cc'
+        obj_combo_hash = '16c5a5a06'
+        mods_combo_hash = 'f5c8c6fc'
 
         with mock.patch('pathlib.Path.exists', side_effect=[True, True, False]):  # mod files exist, obj file doesn't
             with mock.patch('fab.steps.compile_fortran.CompileFortran.compile_file') as mock_compile_file:
                 with mock.patch('shutil.copy2') as mock_copy:
                     res = compiler.process_file(analysed_file)
 
-        expect_object_fpath = Path('/fab/proj/build_output/_prebuild/foofile.e2a37224.o')
-        expect = CompiledFile(input_fpath=analysed_file.fpath, output_fpath=expect_object_fpath)
-        assert res == expect, f'{res} != {expect}'
-
+        expect_object_fpath = Path(f'/fab/proj/build_output/_prebuild/foofile.{obj_combo_hash}.o')
+        assert res == CompiledFile(input_fpath=analysed_file.fpath, output_fpath=expect_object_fpath)
         mock_compile_file.assert_called_once_with(analysed_file, flags, output_fpath=expect_object_fpath)
-        self.ensure_mods_stored(mock_copy, mods_combo_hash='6c11df1a')
+        self.ensure_mods_stored(mock_copy, mods_combo_hash)
 
-    @pytest.mark.skip(reason='not yet implemented')
     def test_compiler_version_hash(self):
-        # changing the compiler version must change the combo hash
-        raise NotImplementedError
+        # changing the compiler version must change the combo hash for the mods and obj
+        compiler, flags, analysed_file, obj_combo_hash, mods_combo_hash = self.content()
+
+        compiler.compiler_version = '1.2.4'
+        obj_combo_hash = '17927b778'
+        mods_combo_hash = '10296246e'
+
+        with mock.patch('pathlib.Path.exists', side_effect=[True, True, False]):  # mod files exist, obj file doesn't
+            with mock.patch('fab.steps.compile_fortran.CompileFortran.compile_file') as mock_compile_file:
+                with mock.patch('shutil.copy2') as mock_copy:
+                    res = compiler.process_file(analysed_file)
+
+        expect_object_fpath = Path(f'/fab/proj/build_output/_prebuild/foofile.{obj_combo_hash}.o')
+        assert res == CompiledFile(input_fpath=analysed_file.fpath, output_fpath=expect_object_fpath)
+        mock_compile_file.assert_called_once_with(analysed_file, flags, output_fpath=expect_object_fpath)
+        self.ensure_mods_stored(mock_copy, mods_combo_hash)
 
     def test_mod_missing(self):
-        # one of the mods we define is not present, so we must recompile
-        compiler, flags, analysed_file, expect_object_fpath = self.content()
+        # if one of the mods we define is not present, we must recompile
+        compiler, flags, analysed_file, obj_combo_hash, mods_combo_hash = self.content()
 
         with mock.patch('pathlib.Path.exists', side_effect=[False, True, True]):  # one mod file missing
             with mock.patch('fab.steps.compile_fortran.CompileFortran.compile_file') as mock_compile_file:
                 with mock.patch('shutil.copy2') as mock_copy:
                     res = compiler.process_file(analysed_file)
 
+        expect_object_fpath = Path(f'/fab/proj/build_output/_prebuild/foofile.{obj_combo_hash}.o')
         assert res == CompiledFile(input_fpath=analysed_file.fpath, output_fpath=expect_object_fpath)
         mock_compile_file.assert_called_once_with(analysed_file, flags, output_fpath=expect_object_fpath)
-        self.ensure_mods_stored(mock_copy)
+        self.ensure_mods_stored(mock_copy, mods_combo_hash)
 
     def test_obj_missing(self):
         # the object file we define is not present, so we must recompile
-        compiler, flags, analysed_file, expect_object_fpath = self.content()
+        compiler, flags, analysed_file, obj_combo_hash, mods_combo_hash = self.content()
 
         with mock.patch('pathlib.Path.exists', side_effect=[True, True, False]):  # object file missing
             with mock.patch('fab.steps.compile_fortran.CompileFortran.compile_file') as mock_compile_file:
                 with mock.patch('shutil.copy2') as mock_copy:
                     res = compiler.process_file(analysed_file)
 
+        expect_object_fpath = Path(f'/fab/proj/build_output/_prebuild/foofile.{obj_combo_hash}.o')
         assert res == CompiledFile(input_fpath=analysed_file.fpath, output_fpath=expect_object_fpath)
         mock_compile_file.assert_called_once_with(analysed_file, flags, output_fpath=expect_object_fpath)
-        self.ensure_mods_stored(mock_copy)
+        self.ensure_mods_stored(mock_copy, mods_combo_hash)
+
 
 # todo: test compile_file
+
+
+class Test_get_compiler_version(object):
+
+    def _check(self, full_version_string, expect):
+        with mock.patch('fab.steps.compile_fortran.run_command', return_value=full_version_string):
+            result = _get_compiler_version(None)
+        assert result == expect
+
+    def test_command_failure(self):
+        # if the command fails, we must return an empty string, not None, so it can still be hashed
+        with mock.patch('fab.steps.compile_fortran.run_command', side_effect=RuntimeError()):
+            assert _get_compiler_version(None) == '', 'expected empty string'
+
+    def test_unknown_command_response(self):
+        # if the full version output is in an unknown format, we must return an empty string
+        self._check(full_version_string='foo fortran 1.2.3', expect='')
+
+    def test_unknown_version_format(self):
+        # if the version is in an unknown format, we must return an empty string
+        full_version_string = dedent("""
+            Foo Fortran (Foo) 5 123456 (Foo Hat 4.8.5-44)
+            Copyright (C) 2022 Foo Software Foundation, Inc.
+        """)
+        self._check(full_version_string=full_version_string, expect='')
+
+    def test_2_part_version(self):
+        # test major.minor format
+        full_version_string = dedent("""
+            Foo Fortran (Foo) 5.6 123456 (Foo Hat 4.8.5-44)
+            Copyright (C) 2022 Foo Software Foundation, Inc.
+        """)
+        self._check(full_version_string=full_version_string, expect='5.6')
+
+    # Possibly overkill to cover so many gfortran versions but I had to go check them so might as well add them.
+    # Note: different sources, e.g conda, change the output slightly...
+
+    def test_gfortran_4(self):
+        full_version_string = dedent("""
+            GNU Fortran (GCC) 4.8.5 20150623 (Red Hat 4.8.5-44)
+            Copyright (C) 2015 Free Software Foundation, Inc.
+
+            GNU Fortran comes with NO WARRANTY, to the extent permitted by law.
+            You may redistribute copies of GNU Fortran
+            under the terms of the GNU General Public License.
+            For more information about these matters, see the file named COPYING
+
+        """)
+
+        self._check(full_version_string=full_version_string, expect='4.8.5')
+
+    def test_gfortran_6(self):
+        full_version_string = dedent("""
+            GNU Fortran (GCC) 6.1.0
+            Copyright (C) 2016 Free Software Foundation, Inc.
+            This is free software; see the source for copying conditions.  There is NO
+            warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
+        """)
+
+        self._check(full_version_string=full_version_string, expect='6.1.0')
+
+    def test_gfortran_8(self):
+        full_version_string = dedent("""
+            GNU Fortran (conda-forge gcc 8.5.0-16) 8.5.0
+            Copyright (C) 2018 Free Software Foundation, Inc.
+            This is free software; see the source for copying conditions.  There is NO
+            warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
+        """)
+
+        self._check(full_version_string=full_version_string, expect='8.5.0')
+
+    def test_gfortran_10(self):
+        full_version_string = dedent("""
+            GNU Fortran (conda-forge gcc 10.4.0-16) 10.4.0
+            Copyright (C) 2020 Free Software Foundation, Inc.
+            This is free software; see the source for copying conditions.  There is NO
+            warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
+        """)
+
+        self._check(full_version_string=full_version_string, expect='10.4.0')
+
+    def test_gfortran_12(self):
+        full_version_string = dedent("""
+            GNU Fortran (conda-forge gcc 12.1.0-16) 12.1.0
+            Copyright (C) 2022 Free Software Foundation, Inc.
+            This is free software; see the source for copying conditions.  There is NO
+            warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
+        """)
+
+        self._check(full_version_string=full_version_string, expect='12.1.0')
+
+    def test_ifort_14(self):
+        full_version_string = dedent("""
+            ifort (IFORT) 14.0.3 20140422
+            Copyright (C) 1985-2014 Intel Corporation.  All rights reserved.
+
+        """)
+
+        self._check(full_version_string=full_version_string, expect='14.0.3')
+
+    def test_ifort_15(self):
+        full_version_string = dedent("""
+            ifort (IFORT) 15.0.2 20150121
+            Copyright (C) 1985-2015 Intel Corporation.  All rights reserved.
+
+        """)
+
+        self._check(full_version_string=full_version_string, expect='15.0.2')
+
+    def test_ifort_17(self):
+        full_version_string = dedent("""
+            ifort (IFORT) 17.0.7 20180403
+            Copyright (C) 1985-2018 Intel Corporation.  All rights reserved.
+
+        """)
+
+        self._check(full_version_string=full_version_string, expect='17.0.7')
+
+    def test_ifort_19(self):
+        full_version_string = dedent("""
+            ifort (IFORT) 19.0.0.117 20180804
+            Copyright (C) 1985-2018 Intel Corporation.  All rights reserved.
+
+        """)
+
+        self._check(full_version_string=full_version_string, expect='19.0.0.117')


### PR DESCRIPTION
Incorporates the compiler version, when available, into the prebuild "combo hash" for object and module files.
Small change to Fab. Most of this PR is changes and additions to the test code.

Todo:
 - [x] Merge #145
 - [x] update after merge