### PR TITLE
"Fixup" analysis prebuild paths

### DIFF
--- a/source/fab/steps/compile_fortran.py
+++ b/source/fab/steps/compile_fortran.py
@@ -261,22 +261,6 @@ class CompileFortran(Step):
         except TypeError:
             raise ValueError("could not generate combo hash for object file")
 
-        # # remote debugging aid - remove!
-        # print(
-        #     '-----------------\n'
-        #     f'{analysed_file.fpath}\n'
-        #     f'analysed_file.file_hash {analysed_file.file_hash}\n'
-        #     f'flags {flags}\n'
-        #     f'flags_checksum(flags) {flags_checksum(flags)}\n'
-        #     f'mod_deps_hashes {mod_deps_hashes}\n'
-        #     f'sum(mod_deps_hashes.values()) {sum(mod_deps_hashes.values())}\n'
-        #     f'self.compiler {self.compiler}\n'
-        #     f'zlib.crc32(self.compiler.encode()) {zlib.crc32(self.compiler.encode())}\n'
-        #     '-----------------\n'
-        #     f'obj_combo_hash {obj_combo_hash}\n'
-        #     '-----------------\n'
-        # )
-
         return obj_combo_hash
 
     def _get_mod_combo_hash(self, analysed_file):

--- a/source/fab/steps/compile_fortran.py
+++ b/source/fab/steps/compile_fortran.py
@@ -260,6 +260,23 @@ class CompileFortran(Step):
             ])
         except TypeError:
             raise ValueError("could not generate combo hash for object file")
+
+        # # remote debugging aid - remove!
+        # print(
+        #     '-----------------\n'
+        #     f'{analysed_file.fpath}\n'
+        #     f'analysed_file.file_hash {analysed_file.file_hash}\n'
+        #     f'flags {flags}\n'
+        #     f'flags_checksum(flags) {flags_checksum(flags)}\n'
+        #     f'mod_deps_hashes {mod_deps_hashes}\n'
+        #     f'sum(mod_deps_hashes.values()) {sum(mod_deps_hashes.values())}\n'
+        #     f'self.compiler {self.compiler}\n'
+        #     f'zlib.crc32(self.compiler.encode()) {zlib.crc32(self.compiler.encode())}\n'
+        #     '-----------------\n'
+        #     f'obj_combo_hash {obj_combo_hash}\n'
+        #     '-----------------\n'
+        # )
+
         return obj_combo_hash
 
     def _get_mod_combo_hash(self, analysed_file):

--- a/source/fab/tasks/fortran.py
+++ b/source/fab/tasks/fortran.py
@@ -95,7 +95,12 @@ class FortranAnalyser(object):
         file_hash = file_checksum(fpath).file_hash
         analysis_fpath = Path(self._prebuild_folder / f'{fpath.stem}.{file_hash}.an')
         if analysis_fpath.exists():
-            return AnalysedFile.load(analysis_fpath)
+            loaded_result = AnalysedFile.load(analysis_fpath)
+            # Note: This result might have been created by another user, and the prebuild copied here.
+            # If so, the fpath in the result will *not* point to the file we eventually want to compile,
+            # it will point to the user's original file, somewhere else. So, replace it with our own path.
+            loaded_result.fpath = fpath
+            return loaded_result
 
         analysed_file = AnalysedFile(fpath=fpath, file_hash=file_hash)
 

--- a/system-tests-new/prebuild/test_prebuild.py
+++ b/system-tests-new/prebuild/test_prebuild.py
@@ -96,9 +96,12 @@ class TestFortranPrebuild(object):
         assert exe.exists()
 
         # make sure the prebuild files are the same
-        for a in file_walk(first_project.prebuild_folder):
-            b = second_project.prebuild_folder / a.name
-            assert files_identical(a, b)
+        first_prebuilds = {p.name for p in (file_walk(first_project.prebuild_folder))}
+        second_prebuilds = {p.name for p in (file_walk(second_project.prebuild_folder))}
+        assert first_prebuilds == second_prebuilds
+        for fname in first_prebuilds | second_prebuilds:
+            assert files_identical(first_project.prebuild_folder / fname,
+                                   second_project.prebuild_folder / fname)
 
     def test_deleted_original(self, tmp_path):
         # Ensure we compile the files in our source folder and not those specified in analysis prebuilds.

--- a/tests/unit_tests/steps/test_compile_c.py
+++ b/tests/unit_tests/steps/test_compile_c.py
@@ -26,7 +26,8 @@ class Test_CompileC(object):
         # run the step
         with mock.patch('fab.steps.compile_c.run_command') as mock_run_command:
             with mock.patch('fab.steps.compile_c.send_metric') as mock_send_metric:
-                c_compiler.run(artefact_store=artefact_store, config=config)
+                with mock.patch('pathlib.Path.mkdir'):
+                    c_compiler.run(artefact_store=artefact_store, config=config)
 
         # ensure it made the correct command-line call from the child process
         mock_run_command.assert_called_with([
@@ -54,7 +55,8 @@ class Test_CompileC(object):
         with pytest.raises(RuntimeError):
             with mock.patch('fab.steps.compile_c.run_command', side_effect=Exception):
                 with mock.patch('fab.steps.compile_c.send_metric') as mock_send_metric:
-                    c_compiler.run(artefact_store=artefact_store, config=config)
+                    with mock.patch('pathlib.Path.mkdir'):
+                        c_compiler.run(artefact_store=artefact_store, config=config)
 
         # ensure no metric was sent from the child process
         mock_send_metric.assert_not_called()


### PR DESCRIPTION
When we load analysis prebuilds, we know the "local" file for which we want results, but the result file contains the _original_ path. This was causing the compiler to try to compile _the original source_ from the prebuild provider, instead of our local source.
This fix applies a "fixup" to the loaded result path. A new test is included which deletes the original source and fails without the fix.