### PR TITLE
remove the prebuild sharing between projects in the build_all tests

### DIFF
--- a/run_configs/build_all.py
+++ b/run_configs/build_all.py
@@ -17,8 +17,9 @@ def build_all():
     compiler, _ = get_compiler()
 
     os.environ['FAB_WORKSPACE'] = os.path.join(os.getcwd(), f'fab_build_all_{compiler}')
-    # save a bit of time if we're processing the same code in different projects
-    os.environ['FAB_PREBUILD'] = os.path.join(os.environ['FAB_WORKSPACE'], '_prebuild')
+
+    # CAUTION: This flag breaks jules rebuild. We haven't investigated this yet in depth. It's concerning.
+    # os.environ['FAB_PREBUILD'] = os.path.join(os.environ['FAB_WORKSPACE'], '_prebuild')
 
     scripts = [
         configs_folder / 'gcom/grab_gcom.py',
@@ -36,7 +37,7 @@ def build_all():
     ]
 
     # skip these for now, until we configure them to build again
-    compiler_skip = {'gfortran': ['atm.py'], 'ifort': ['build_um.py', 'atm.py']}
+    compiler_skip = {'gfortran': [], 'ifort': ['build_um.py', 'atm.py']}
     skip = compiler_skip[compiler]
 
     for script in scripts:


### PR DESCRIPTION
Sharing the prebuild folder across projects breaks (at least) atm build and jules rebuild with gfortran, causing a 4 vs 8 byte type mistmatch. This is a cause for concern because the prebuild code isolates the artefacts by hashing the compile flags and more.

I don't think this PR should block the beta release as I['](https://i.pinimg.com/originals/07/94/8f/07948f3fe9076fc809cf5c2f2ab8b1dd.png)m the only one currently running this manual test. However, the shared prebuild problem itself should probably block the release until we understand it.