### PR TITLE
Error output formatting

### DIFF
--- a/source/fab/build_config.py
+++ b/source/fab/build_config.py
@@ -144,8 +144,7 @@ class BuildConfig(object):
                         step.run(artefact_store=self._artefact_store, config=self)
                     send_metric('steps', step.name, step_timer.taken)
         except Exception as err:
-            # logger.error(f'\n\nError running build steps:\n{err}')
-            logger.exception(f'\n\nError running build steps')
+            logger.exception('\n\nError running build steps')
             raise Exception(f'\n\nError running build steps:\n{err}')
         finally:
             self._finalise_metrics(start_time, steps_timer)

--- a/source/fab/build_config.py
+++ b/source/fab/build_config.py
@@ -144,7 +144,8 @@ class BuildConfig(object):
                         step.run(artefact_store=self._artefact_store, config=self)
                     send_metric('steps', step.name, step_timer.taken)
         except Exception as err:
-            logger.error(f'\n\nError running build steps:\n{err}')
+            # logger.error(f'\n\nError running build steps:\n{err}')
+            logger.exception(f'\n\nError running build steps')
             raise Exception(f'\n\nError running build steps:\n{err}')
         finally:
             self._finalise_metrics(start_time, steps_timer)

--- a/source/fab/metrics.py
+++ b/source/fab/metrics.py
@@ -242,14 +242,18 @@ def metrics_summary(metrics_folder: Path):
     run = metrics['run']
     time_taken = datetime.timedelta(seconds=int(run['time taken']))
     min_label_thresh = time_taken.seconds * 0.01
-    step_metrics = metrics['steps'].items()
-    step_times = [kv[1] for kv in step_metrics]
-    step_labels = [kv[0] if kv[1] > min_label_thresh else "" for kv in step_metrics]
+    step_totals = metrics.get('steps')
+    if step_totals:
+        step_metrics = step_totals.items()
+        step_times = [kv[1] for kv in step_metrics]
+        step_labels = [kv[0] if kv[1] > min_label_thresh else "" for kv in step_metrics]
 
-    plt.pie(step_times, labels=step_labels, normalize=True,
-            wedgeprops={"linewidth": 1, "edgecolor": "white"})
-    plt.suptitle(f"{run['label']} took {time_taken}\n"
-                 f"on {run['sysname']}, {run['nodename']}, {run['machine']}")
-    plt.figtext(0.99, 0.01, f"{metrics['run']['datetime']}", horizontalalignment='right', fontsize='x-small')
-    plt.savefig(metrics_folder / "pie.png")
-    plt.close()
+        plt.pie(step_times, labels=step_labels, normalize=True,
+                wedgeprops={"linewidth": 1, "edgecolor": "white"})
+        plt.suptitle(f"{run['label']} took {time_taken}\n"
+                     f"on {run['sysname']}, {run['nodename']}, {run['machine']}")
+        plt.figtext(0.99, 0.01, f"{metrics['run']['datetime']}", horizontalalignment='right', fontsize='x-small')
+        plt.savefig(metrics_folder / "pie.png")
+        plt.close()
+    else:
+        logger.info("no metrics data 'steps' for step totals pie chart")

--- a/source/fab/steps/archive_objects.py
+++ b/source/fab/steps/archive_objects.py
@@ -132,6 +132,6 @@ class ArchiveObjects(Step):
             try:
                 run_command(command)
             except Exception as err:
-                raise Exception(f"error creating object archive: {err}")
+                raise Exception(f"error creating object archive:\n{err}")
 
             output_archives[root] = [output_fpath]

--- a/source/fab/steps/compile_c.py
+++ b/source/fab/steps/compile_c.py
@@ -114,7 +114,7 @@ class CompileC(Step):
                 try:
                     run_command(command)
                 except Exception as err:
-                    return TaskException(f"error compiling {analysed_file.fpath}: {err}")
+                    return TaskException(f"error compiling {analysed_file.fpath}:\n{err}")
 
             send_metric(self.name, str(analysed_file.fpath), timer.taken)
 

--- a/source/fab/steps/compile_fortran.py
+++ b/source/fab/steps/compile_fortran.py
@@ -238,7 +238,7 @@ class CompileFortran(Step):
                 logger.debug(f'CompileFortran compiling {analysed_file.fpath}')
                 self.compile_file(analysed_file, flags, output_fpath=obj_file_prebuild)
             except Exception as err:
-                return Exception(f"Error compiling {analysed_file.fpath}: {err}")
+                return Exception(f"Error compiling {analysed_file.fpath}:\n{err}")
 
             # Store the mod files for reuse.
             # todo: we could sometimes avoid these copies because mods can change less frequently than obj
@@ -366,7 +366,7 @@ def _get_compiler_version(compiler: str) -> str:
     except FileNotFoundError:
         raise ValueError(f'Compiler not found: {compiler}')
     except RuntimeError as err:
-        logger.warning(f"Error asking for version of compiler '{compiler}': {err}")
+        logger.warning(f"Error asking for version of compiler '{compiler}':\n{err}")
         return ''
 
     # Pull the version string from the command output.

--- a/source/fab/steps/grab.py
+++ b/source/fab/steps/grab.py
@@ -182,7 +182,7 @@ class GrabPreBuild(Step):
             logger.info('\n'.join(to_print))
 
         except RuntimeError as err:
-            msg = f"could not grab pre-build '{self.src}': {err}"
+            msg = f"could not grab pre-build '{self.src}':\n{err}"
             logger.warning(msg)
             if not self.allow_fail:
                 raise RuntimeError(msg)

--- a/source/fab/steps/link.py
+++ b/source/fab/steps/link.py
@@ -78,7 +78,7 @@ class LinkerBase(Step, ABC):
         try:
             run_command(command)
         except Exception as err:
-            raise Exception(f"error linking: {err}")
+            raise Exception(f"error linking:\n{err}")
 
 
 class LinkExe(LinkerBase):

--- a/source/fab/steps/preprocess.py
+++ b/source/fab/steps/preprocess.py
@@ -117,7 +117,7 @@ class PreProcessor(Step):
                 try:
                     run_command(command)
                 except Exception as err:
-                    raise Exception(f"error preprocessing {fpath}: {err}")
+                    raise Exception(f"error preprocessing {fpath}:\n{err}")
 
             send_metric(self.name, str(fpath), {'time_taken': timer.taken, 'start': timer.start})
 

--- a/tests/unit_tests/test_build_config.py
+++ b/tests/unit_tests/test_build_config.py
@@ -26,11 +26,11 @@ class TestBuildConfig(object):
                 config = BuildConfig('proj', fab_workspace=tmp_path, multiprocessing=False, steps=[
                     CompileFortran(compiler='foofc')])
 
-        run_mp = 'fab.steps.compile_fortran.CompileFortran.run_mp'
+        run_mp = 'fab.steps.compile_fortran.run_command'
         err = dedent("foo error\n1\n2\n3")
 
         try:
-            with mock.patch(run_mp, return_value=[ValueError(err)]):
+            with mock.patch(run_mp, side_effect=RuntimeError(err)):
                 config.run()
         except Exception as err:
             assert '1\n2\n3' in str(err)

--- a/tests/unit_tests/test_build_config.py
+++ b/tests/unit_tests/test_build_config.py
@@ -1,0 +1,36 @@
+# ##############################################################################
+#  (c) Crown copyright Met Office. All rights reserved.
+#  For further details please refer to the file COPYRIGHT
+#  which you should have received as part of this distribution
+# ##############################################################################
+from textwrap import dedent
+from unittest import mock
+
+from fab.build_config import BuildConfig
+from fab.dep_tree import AnalysedFile
+from fab.steps.compile_fortran import CompileFortran
+
+
+class TestBuildConfig(object):
+
+    def test_error_newlines(self, tmp_path):
+        # Check cli tool errors have newlines displayed correctly (#164).
+        # It's up to the various steps to insert newlines *between* their message and the tool error.
+        # We're testing the general reporting mechanism here, once they get back to the top,
+        # that the newlines *within* the tool error are displayed correctly.
+
+        mock_source = {None: [AnalysedFile('foo.f', file_hash=0)]}
+
+        with mock.patch('fab.steps.compile_fortran._get_compiler_version', return_value='1.2.3'):
+            with mock.patch('fab.steps.compile_fortran.DEFAULT_SOURCE_GETTER', return_value=mock_source):
+                config = BuildConfig('proj', fab_workspace=tmp_path, multiprocessing=False, steps=[
+                    CompileFortran(compiler='foofc')])
+
+        run_mp = 'fab.steps.compile_fortran.CompileFortran.run_mp'
+        err = dedent("foo error\n1\n2\n3")
+
+        try:
+            with mock.patch(run_mp, return_value=[ValueError(err)]):
+                config.run()
+        except Exception as err:
+            assert '1\n2\n3' in str(err)

--- a/tests/unit_tests/test_build_config.py
+++ b/tests/unit_tests/test_build_config.py
@@ -14,7 +14,8 @@ from fab.steps.compile_fortran import CompileFortran
 class TestBuildConfig(object):
 
     def test_error_newlines(self, tmp_path):
-        # Check cli tool errors have newlines displayed correctly (#164).
+        # Check cli tool errors have newlines displayed correctly.
+        # v0.9.0a1 displayed then as `\\n` (see #164).
         # It's up to the various steps to insert newlines *between* their message and the tool error.
         # We're testing the general reporting mechanism here, once they get back to the top,
         # that the newlines *within* the tool error are displayed correctly.

--- a/tests/unit_tests/test_build_config.py
+++ b/tests/unit_tests/test_build_config.py
@@ -26,11 +26,11 @@ class TestBuildConfig(object):
                 config = BuildConfig('proj', fab_workspace=tmp_path, multiprocessing=False, steps=[
                     CompileFortran(compiler='foofc')])
 
-        run_mp = 'fab.steps.compile_fortran.run_command'
+        run_command = 'fab.steps.compile_fortran.run_command'
         err = dedent("foo error\n1\n2\n3")
 
         try:
-            with mock.patch(run_mp, side_effect=RuntimeError(err)):
+            with mock.patch(run_command, side_effect=RuntimeError(err)):
                 config.run()
         except Exception as err:
             assert '1\n2\n3' in str(err)


### PR DESCRIPTION
Insert a newline before tool output in error messages, for #164.  The user was also seeing newlines _within_ the error messages being printed as `\\n` but that has already been addressed.

Also: The new test only has one step, which deliberately fails, so there's never any step timings in the metrics. This PR includes a change which stops that from causing a key error.

todo:
 - [x] #168 then update this
 - [x] #169 then backport this