### PR TITLE
185 Rose suite system tests

### DIFF
--- a/run_configs/_rose_all/rose-suite.conf
+++ b/run_configs/_rose_all/rose-suite.conf
@@ -49,8 +49,3 @@ source=$PWD/../lfric/gungho.py
 
 [file:bin/atm.py]
 source=$PWD/../lfric/atm.py
-
-
-[jinja2:suite.rc]
-PYTHON_VERSIONS=['7', '11']
-COMPILERS=['gnu', 'ifort']

--- a/run_configs/_rose_all/rose-suite.conf
+++ b/run_configs/_rose_all/rose-suite.conf
@@ -1,6 +1,7 @@
 [env]
 
-# gcom files
+
+# gcom
 [file:bin/build_gcom_ar.py]
 source=$PWD/../gcom/build_gcom_ar.py
 
@@ -15,6 +16,40 @@ source=$PWD/../gcom/grab_gcom.py
 
 [jinja2:suite.rc]
 GCOM_REVISION='vn7.6'
+
+
+# jules
+[file:bin/build_jules.py]
+source=$PWD/../jules/build_jules.py
+
+[jinja2:suite.rc]
+JULES_REVISION='vn6.3'
+
+
+# um
+[file:bin/build_um.py]
+source=$PWD/../um/build_um.py
+
+[jinja2:suite.rc]
+UM_REVISION='vn12.1'
+
+
+# lfric
+[file:bin/lfric_common.py]
+source=$PWD/../lfric/lfric_common.py
+
+[file:bin/grab_lfric.py]
+source=$PWD/../lfric/grab_lfric.py
+
+[file:bin/mesh_tools.py]
+source=$PWD/../lfric/mesh_tools.py
+
+[file:bin/gungho.py]
+source=$PWD/../lfric/gungho.py
+
+[file:bin/atm.py]
+source=$PWD/../lfric/atm.py
+
 
 [jinja2:suite.rc]
 PYTHON_VERSIONS=['7', '11']

--- a/run_configs/_rose_all/rose-suite.conf
+++ b/run_configs/_rose_all/rose-suite.conf
@@ -1,0 +1,21 @@
+[env]
+
+# gcom files
+[file:bin/build_gcom_ar.py]
+source=$PWD/../gcom/build_gcom_ar.py
+
+[file:bin/build_gcom_so.py]
+source=$PWD/../gcom/build_gcom_so.py
+
+[file:bin/gcom_build_steps.py]
+source=$PWD/../gcom/gcom_build_steps.py
+
+[file:bin/grab_gcom.py]
+source=$PWD/../gcom/grab_gcom.py
+
+[jinja2:suite.rc]
+GCOM_REVISION='vn7.6'
+
+[jinja2:suite.rc]
+PYTHON_VERSIONS=['7', '11']
+COMPILERS=['gnu', 'ifort']

--- a/run_configs/_rose_all/suite.rc
+++ b/run_configs/_rose_all/suite.rc
@@ -1,89 +1,84 @@
+[cylc]
+    [[parameters]]
+        pyver = "7", "11"  # we can't put a full stop in params, like "3.7", because it causes invalid job names
+        compiler = gnu, ifort
+
 [scheduling]
     [[dependencies]]
-        {% for PYTHON_VERSION in PYTHON_VERSIONS %}
-            {% for COMPILER in COMPILERS %}
-                graph = """
-                    grab_gcom_py{{ PYTHON_VERSION }}_{{ COMPILER }} => build_gcom_ar_py{{ PYTHON_VERSION }}_{{ COMPILER }}
-                    grab_gcom_py{{ PYTHON_VERSION }}_{{ COMPILER }} => build_gcom_so_py{{ PYTHON_VERSION }}_{{ COMPILER }}
-                    build_jules_py{{ PYTHON_VERSION }}_{{ COMPILER }}
-                    build_gcom_ar_py{{ PYTHON_VERSION }}_{{ COMPILER }} => build_um_py{{ PYTHON_VERSION }}_{{ COMPILER }}
-                    grab_lfric_py{{ PYTHON_VERSION }}_{{ COMPILER }} => mesh_tools_py{{ PYTHON_VERSION }}_{{ COMPILER }}
-                    grab_lfric_py{{ PYTHON_VERSION }}_{{ COMPILER }} => gungho_py{{ PYTHON_VERSION }}_{{ COMPILER }}
-                    grab_lfric_py{{ PYTHON_VERSION }}_{{ COMPILER }} => atm_py{{ PYTHON_VERSION }}_{{ COMPILER }}
-                   """
-            {% endfor %}
-        {% endfor %}
+        graph = """
+            grab_gcom<pyver,compiler> => build_gcom_ar<pyver,compiler>
+            grab_gcom<pyver,compiler> => build_gcom_so<pyver,compiler>
+            build_jules<pyver,compiler>
+            build_gcom_ar<pyver,compiler> => build_um<pyver,compiler>
+            grab_lfric<pyver,compiler> => mesh_tools<pyver,compiler>
+            grab_lfric<pyver,compiler> => gungho<pyver,compiler>
+            grab_lfric<pyver,compiler> => atm<pyver,compiler>
+        """
 
 [runtime]
 
-    {% for PYTHON_VERSION in PYTHON_VERSIONS %}
-        {% for COMPILER in COMPILERS %}
+    [[common<pyver,compiler>]]
 
-            [[common_py{{ PYTHON_VERSION }}_{{ COMPILER }}]]
+        env-script = """
+            module use /data/users/lfric/modules/modulefiles.rhel7
+            module load environment/lfric/$CYLC_TASK_PARAM_compiler
+            conda init bash
+            conda activate sci-fab-3.$CYLC_TASK_PARAM_pyver
+        """
 
-                env-script = """
-                    module use /data/users/lfric/modules/modulefiles.rhel7
-                    module load environment/lfric/{{ COMPILER }}
-                    conda init bash
-                    conda activate sci-fab-3.{{ PYTHON_VERSION }}
-                """
+        [[[job]]]
+            batch system = slurm
+            execution time limit = PT30M
+        [[[directives]]]
+            --mem=512
+            --cpus-per-task=4
+            --export=NONE
+        [[[environment]]]
+            FAB_WORKSPACE=$SCRATCH/fab_workspace_py3.${CYLC_TASK_PARAM_pyver}_$CYLC_TASK_PARAM_compiler
+            GCOM_REVISION={{ GCOM_REVISION }}
 
-                [[[job]]]
-                    batch system = slurm
-                    execution time limit = PT30M
-                [[[directives]]]
-                    --mem=512
-                    --cpus-per-task=4
-                    --export=NONE
-                [[[environment]]]
-                    FAB_WORKSPACE=$SCRATCH/fab_workspace_py3.{{ PYTHON_VERSION }}_{{ COMPILER }}
-                    GCOM_REVISION={{ GCOM_REVISION }}
+    [[grab_gcom<pyver,compiler>]]
+        inherit = 'common<pyver,compiler>'
+        script = grab_gcom.py
 
-            [[grab_gcom_py{{ PYTHON_VERSION }}_{{ COMPILER }}]]
-                inherit = common_py{{ PYTHON_VERSION }}_{{ COMPILER }}
-                script = grab_gcom.py
+    [[build_gcom_ar<pyver,compiler>]]
+        inherit = 'common<pyver,compiler>'
+        script = build_gcom_ar.py
 
-            [[build_gcom_ar_py{{ PYTHON_VERSION }}_{{ COMPILER }}]]
-                inherit = common_py{{ PYTHON_VERSION }}_{{ COMPILER }}
-                script = build_gcom_ar.py
+    [[build_gcom_so<pyver,compiler>]]
+        inherit = 'common<pyver,compiler>'
+        script = build_gcom_so.py
 
-            [[build_gcom_so_py{{ PYTHON_VERSION }}_{{ COMPILER }}]]
-                inherit = common_py{{ PYTHON_VERSION }}_{{ COMPILER }}
-                script = build_gcom_so.py
+    [[build_jules<pyver,compiler>]]
+        inherit = 'common<pyver,compiler>'
+        script = build_jules.py
+        [[[directives]]]
+            --mem=1024
 
-            [[build_jules_py{{ PYTHON_VERSION }}_{{ COMPILER }}]]
-                inherit = common_py{{ PYTHON_VERSION }}_{{ COMPILER }}
-                script = build_jules.py
-                [[[directives]]]
-                    --mem=1024
+    [[build_um<pyver,compiler>]]
+        inherit = 'common<pyver,compiler>'
+        script = build_jules.py
+        [[[directives]]]
+            --mem=2048
 
-            [[build_um_py{{ PYTHON_VERSION }}_{{ COMPILER }}]]
-                inherit = common_py{{ PYTHON_VERSION }}_{{ COMPILER }}
-                script = build_jules.py
-                [[[directives]]]
-                    --mem=2048
+    [[grab_lfric<pyver,compiler>]]
+        inherit = 'common<pyver,compiler>'
+        script = grab_lfric.py
 
-            [[grab_lfric_py{{ PYTHON_VERSION }}_{{ COMPILER }}]]
-                inherit = common_py{{ PYTHON_VERSION }}_{{ COMPILER }}
-                script = grab_lfric.py
+    [[mesh_tools<pyver,compiler>]]
+        inherit = 'common<pyver,compiler>'
+        script = mesh_tools.py
+        [[[directives]]]
+            --mem=1024
 
-            [[mesh_tools_py{{ PYTHON_VERSION }}_{{ COMPILER }}]]
-                inherit = common_py{{ PYTHON_VERSION }}_{{ COMPILER }}
-                script = mesh_tools.py
-                [[[directives]]]
-                    --mem=1024
+    [[gungho<pyver,compiler>]]
+        inherit = 'common<pyver,compiler>'
+        script = gungho.py
+        [[[directives]]]
+            --mem=2048
 
-            [[gungho_py{{ PYTHON_VERSION }}_{{ COMPILER }}]]
-                inherit = common_py{{ PYTHON_VERSION }}_{{ COMPILER }}
-                script = gungho.py
-                [[[directives]]]
-                    --mem=2048
-
-            [[atm_py{{ PYTHON_VERSION }}_{{ COMPILER }}]]
-                inherit = common_py{{ PYTHON_VERSION }}_{{ COMPILER }}
-                script = atm.py
-                [[[directives]]]
-                    --mem=2048
-
-        {% endfor %}
-    {% endfor %}
+    [[atm<pyver,compiler>]]
+        inherit = 'common<pyver,compiler>'
+        script = atm.py
+        [[[directives]]]
+            --mem=2048

--- a/run_configs/_rose_all/suite.rc
+++ b/run_configs/_rose_all/suite.rc
@@ -30,7 +30,7 @@
 
                 [[[job]]]
                     batch system = slurm
-                    execution time limit = PT10M
+                    execution time limit = PT30M
                 [[[directives]]]
                     --mem=512
                     --cpus-per-task=4

--- a/run_configs/_rose_all/suite.rc
+++ b/run_configs/_rose_all/suite.rc
@@ -5,6 +5,11 @@
                 graph = """
                     grab_gcom_py{{ PYTHON_VERSION }}_{{ COMPILER }} => build_gcom_ar_py{{ PYTHON_VERSION }}_{{ COMPILER }}
                     grab_gcom_py{{ PYTHON_VERSION }}_{{ COMPILER }} => build_gcom_so_py{{ PYTHON_VERSION }}_{{ COMPILER }}
+                    build_jules_py{{ PYTHON_VERSION }}_{{ COMPILER }}
+                    build_gcom_ar_py{{ PYTHON_VERSION }}_{{ COMPILER }} => build_um_py{{ PYTHON_VERSION }}_{{ COMPILER }}
+                    grab_lfric_py{{ PYTHON_VERSION }}_{{ COMPILER }} => mesh_tools_py{{ PYTHON_VERSION }}_{{ COMPILER }}
+                    grab_lfric_py{{ PYTHON_VERSION }}_{{ COMPILER }} => gungho_py{{ PYTHON_VERSION }}_{{ COMPILER }}
+                    grab_lfric_py{{ PYTHON_VERSION }}_{{ COMPILER }} => atm_py{{ PYTHON_VERSION }}_{{ COMPILER }}
                    """
             {% endfor %}
         {% endfor %}
@@ -27,7 +32,7 @@
                     batch system = slurm
                     execution time limit = PT10M
                 [[[directives]]]
-                    --mem=500
+                    --mem=512
                     --cpus-per-task=4
                     --export=NONE
                 [[[environment]]]
@@ -45,6 +50,40 @@
             [[build_gcom_so_py{{ PYTHON_VERSION }}_{{ COMPILER }}]]
                 inherit = common_py{{ PYTHON_VERSION }}_{{ COMPILER }}
                 script = build_gcom_so.py
+
+            [[build_jules_py{{ PYTHON_VERSION }}_{{ COMPILER }}]]
+                inherit = common_py{{ PYTHON_VERSION }}_{{ COMPILER }}
+                script = build_jules.py
+                [[[directives]]]
+                    --mem=1024
+
+            [[build_um_py{{ PYTHON_VERSION }}_{{ COMPILER }}]]
+                inherit = common_py{{ PYTHON_VERSION }}_{{ COMPILER }}
+                script = build_jules.py
+                [[[directives]]]
+                    --mem=2048
+
+            [[grab_lfric_py{{ PYTHON_VERSION }}_{{ COMPILER }}]]
+                inherit = common_py{{ PYTHON_VERSION }}_{{ COMPILER }}
+                script = grab_lfric.py
+
+            [[mesh_tools_py{{ PYTHON_VERSION }}_{{ COMPILER }}]]
+                inherit = common_py{{ PYTHON_VERSION }}_{{ COMPILER }}
+                script = mesh_tools.py
+                [[[directives]]]
+                    --mem=1024
+
+            [[gungho_py{{ PYTHON_VERSION }}_{{ COMPILER }}]]
+                inherit = common_py{{ PYTHON_VERSION }}_{{ COMPILER }}
+                script = gungho.py
+                [[[directives]]]
+                    --mem=2048
+
+            [[atm_py{{ PYTHON_VERSION }}_{{ COMPILER }}]]
+                inherit = common_py{{ PYTHON_VERSION }}_{{ COMPILER }}
+                script = atm.py
+                [[[directives]]]
+                    --mem=2048
 
         {% endfor %}
     {% endfor %}

--- a/run_configs/_rose_all/suite.rc
+++ b/run_configs/_rose_all/suite.rc
@@ -1,0 +1,50 @@
+[scheduling]
+    [[dependencies]]
+        {% for PYTHON_VERSION in PYTHON_VERSIONS %}
+            {% for COMPILER in COMPILERS %}
+                graph = """
+                    grab_gcom_py{{ PYTHON_VERSION }}_{{ COMPILER }} => build_gcom_ar_py{{ PYTHON_VERSION }}_{{ COMPILER }}
+                    grab_gcom_py{{ PYTHON_VERSION }}_{{ COMPILER }} => build_gcom_so_py{{ PYTHON_VERSION }}_{{ COMPILER }}
+                   """
+            {% endfor %}
+        {% endfor %}
+
+[runtime]
+
+    {% for PYTHON_VERSION in PYTHON_VERSIONS %}
+        {% for COMPILER in COMPILERS %}
+
+            [[common_py{{ PYTHON_VERSION }}_{{ COMPILER }}]]
+
+                env-script = """
+                    module use /data/users/lfric/modules/modulefiles.rhel7
+                    module load environment/lfric/{{ COMPILER }}
+                    conda init bash
+                    conda activate sci-fab-3.{{ PYTHON_VERSION }}
+                """
+
+                [[[job]]]
+                    batch system = slurm
+                    execution time limit = PT10M
+                [[[directives]]]
+                    --mem=500
+                    --cpus-per-task=4
+                    --export=NONE
+                [[[environment]]]
+                    FAB_WORKSPACE=$SCRATCH/fab_workspace_py3.{{ PYTHON_VERSION }}_{{ COMPILER }}
+                    GCOM_REVISION={{ GCOM_REVISION }}
+
+            [[grab_gcom_py{{ PYTHON_VERSION }}_{{ COMPILER }}]]
+                inherit = common_py{{ PYTHON_VERSION }}_{{ COMPILER }}
+                script = grab_gcom.py
+
+            [[build_gcom_ar_py{{ PYTHON_VERSION }}_{{ COMPILER }}]]
+                inherit = common_py{{ PYTHON_VERSION }}_{{ COMPILER }}
+                script = build_gcom_ar.py
+
+            [[build_gcom_so_py{{ PYTHON_VERSION }}_{{ COMPILER }}]]
+                inherit = common_py{{ PYTHON_VERSION }}_{{ COMPILER }}
+                script = build_gcom_so.py
+
+        {% endfor %}
+    {% endfor %}


### PR DESCRIPTION
I'm losing a fair bit of time waiting for the offline system tests to run on the VDI. This rose suite runs them all in parallel. It's quicker ~and I can work while they run~.

This suite runs all the MO projects we regularly build with Fab. It builds them with Python versions 3.7 and 3.11, and it builds them with both gfortran and ifort.

This method of running the offline system tests differs from the nightly cron in that it runs the currently checked out branch, not the head of trunk.

todo:
 - [x] check they all build ok
    - (except for the couple of ifort ones we haven't configured properly yet)

Resolves #185