### PR TITLE
174 incremental c

### DIFF
--- a/run_configs/build_all.py
+++ b/run_configs/build_all.py
@@ -7,7 +7,7 @@
 import os
 from pathlib import Path
 
-from fab.steps.compile_fortran import get_compiler
+from fab.steps.compile_fortran import get_fortran_compiler
 from fab.util import run_command
 
 
@@ -15,7 +15,7 @@ from fab.util import run_command
 def build_all():
 
     configs_folder = Path(__file__).parent
-    compiler, _ = get_compiler()
+    compiler, _ = get_fortran_compiler()
 
     os.environ['FAB_WORKSPACE'] = os.path.join(os.getcwd(), f'fab_build_all_{compiler}')
 

--- a/run_configs/build_all.py
+++ b/run_configs/build_all.py
@@ -7,14 +7,15 @@
 import os
 from pathlib import Path
 
-from fab.util import run_command, get_tool
+from fab.steps.compile_fortran import get_fortran_compiler
+from fab.util import run_command
 
 
 # todo: run the exes, check the output
 def build_all():
 
     configs_folder = Path(__file__).parent
-    compiler, _ = get_tool(os.getenv('FC'))
+    compiler, _ = get_fortran_compiler()
 
     os.environ['FAB_WORKSPACE'] = os.path.join(os.getcwd(), f'fab_build_all_{compiler}')
 

--- a/run_configs/build_all.py
+++ b/run_configs/build_all.py
@@ -7,15 +7,14 @@
 import os
 from pathlib import Path
 
-from fab.steps.compile_fortran import get_fortran_compiler
-from fab.util import run_command
+from fab.util import run_command, get_tool
 
 
 # todo: run the exes, check the output
 def build_all():
 
     configs_folder = Path(__file__).parent
-    compiler, _ = get_fortran_compiler()
+    compiler, _ = get_tool(os.getenv('FC'))
 
     os.environ['FAB_WORKSPACE'] = os.path.join(os.getcwd(), f'fab_build_all_{compiler}')
 

--- a/run_configs/gcom/build_gcom_ar.py
+++ b/run_configs/gcom/build_gcom_ar.py
@@ -6,7 +6,7 @@
 ##############################################################################
 from fab.build_config import BuildConfig
 from fab.steps.archive_objects import ArchiveObjects
-from fab.steps.compile_fortran import get_compiler
+from fab.steps.compile_fortran import get_fortran_compiler
 from gcom_build_steps import common_build_steps, parse_args
 from grab_gcom import gcom_grab_config
 
@@ -17,7 +17,7 @@ def gcom_ar_config(revision=None, compiler=None):
 
     """
     # We want a separate project folder for each compiler. Find out which compiler we'll be using.
-    compiler, _ = get_compiler(compiler)
+    compiler, _ = get_fortran_compiler(compiler)
 
     config = BuildConfig(
         project_label=f'gcom object archive {revision} {compiler}',

--- a/run_configs/gcom/build_gcom_ar.py
+++ b/run_configs/gcom/build_gcom_ar.py
@@ -4,9 +4,12 @@
 # For further details please refer to the file COPYRIGHT
 # which you should have received as part of this distribution
 ##############################################################################
+import os
+
 from fab.build_config import BuildConfig
 from fab.steps.archive_objects import ArchiveObjects
-from fab.steps.compile_fortran import get_fortran_compiler
+from fab.util import get_tool
+
 from gcom_build_steps import common_build_steps, parse_args
 from grab_gcom import gcom_grab_config
 
@@ -17,7 +20,7 @@ def gcom_ar_config(revision=None, compiler=None):
 
     """
     # We want a separate project folder for each compiler. Find out which compiler we'll be using.
-    compiler, _ = get_fortran_compiler(compiler)
+    compiler, _ = get_tool(os.getenv('FC'))
 
     config = BuildConfig(
         project_label=f'gcom object archive {revision} {compiler}',

--- a/run_configs/gcom/build_gcom_ar.py
+++ b/run_configs/gcom/build_gcom_ar.py
@@ -4,11 +4,10 @@
 # For further details please refer to the file COPYRIGHT
 # which you should have received as part of this distribution
 ##############################################################################
-import os
 
 from fab.build_config import BuildConfig
 from fab.steps.archive_objects import ArchiveObjects
-from fab.util import get_tool
+from fab.steps.compile_fortran import get_fortran_compiler
 
 from gcom_build_steps import common_build_steps, parse_args
 from grab_gcom import gcom_grab_config
@@ -20,7 +19,7 @@ def gcom_ar_config(revision=None, compiler=None):
 
     """
     # We want a separate project folder for each compiler. Find out which compiler we'll be using.
-    compiler, _ = get_tool(os.getenv('FC'))
+    compiler, _ = get_fortran_compiler(compiler)
 
     config = BuildConfig(
         project_label=f'gcom object archive {revision} {compiler}',

--- a/run_configs/gcom/build_gcom_so.py
+++ b/run_configs/gcom/build_gcom_so.py
@@ -4,10 +4,12 @@
 # For further details please refer to the file COPYRIGHT
 # which you should have received as part of this distribution
 ##############################################################################
-from fab.steps.compile_fortran import get_fortran_compiler
-from fab.steps.link import LinkSharedObject
+import os
 
 from fab.build_config import BuildConfig
+from fab.steps.link import LinkSharedObject
+from fab.util import get_tool
+
 from gcom_build_steps import common_build_steps, parse_args
 from grab_gcom import gcom_grab_config
 
@@ -18,7 +20,7 @@ def gcom_so_config(revision=None, compiler=None):
 
     """
     # We want a separate project folder for each compiler. Find out which compiler we'll be using.
-    compiler, _ = get_fortran_compiler(compiler)
+    compiler, _ = get_tool(os.getenv('FC'))
 
     config = BuildConfig(
         project_label=f'gcom shared library {revision} {compiler}',

--- a/run_configs/gcom/build_gcom_so.py
+++ b/run_configs/gcom/build_gcom_so.py
@@ -4,7 +4,7 @@
 # For further details please refer to the file COPYRIGHT
 # which you should have received as part of this distribution
 ##############################################################################
-from fab.steps.compile_fortran import get_compiler
+from fab.steps.compile_fortran import get_fortran_compiler
 from fab.steps.link import LinkSharedObject
 
 from fab.build_config import BuildConfig
@@ -18,7 +18,7 @@ def gcom_so_config(revision=None, compiler=None):
 
     """
     # We want a separate project folder for each compiler. Find out which compiler we'll be using.
-    compiler, _ = get_compiler(compiler)
+    compiler, _ = get_fortran_compiler(compiler)
 
     config = BuildConfig(
         project_label=f'gcom shared library {revision} {compiler}',

--- a/run_configs/gcom/build_gcom_so.py
+++ b/run_configs/gcom/build_gcom_so.py
@@ -4,11 +4,9 @@
 # For further details please refer to the file COPYRIGHT
 # which you should have received as part of this distribution
 ##############################################################################
-import os
-
+from fab.steps.compile_fortran import get_fortran_compiler
 from fab.build_config import BuildConfig
 from fab.steps.link import LinkSharedObject
-from fab.util import get_tool
 
 from gcom_build_steps import common_build_steps, parse_args
 from grab_gcom import gcom_grab_config
@@ -20,7 +18,7 @@ def gcom_so_config(revision=None, compiler=None):
 
     """
     # We want a separate project folder for each compiler. Find out which compiler we'll be using.
-    compiler, _ = get_tool(os.getenv('FC'))
+    compiler, _ = get_fortran_compiler(compiler)
 
     config = BuildConfig(
         project_label=f'gcom shared library {revision} {compiler}',

--- a/run_configs/gcom/gcom_build_steps.py
+++ b/run_configs/gcom/gcom_build_steps.py
@@ -6,13 +6,13 @@
 import os
 from typing import List
 
-from fab.steps.preprocess import c_preprocessor, fortran_preprocessor
 
 from fab.steps import Step
 from fab.steps.analyse import Analyse
 from fab.steps.compile_c import CompileC
 from fab.steps.compile_fortran import CompileFortran
 from fab.steps.find_source_files import FindSourceFiles
+from fab.steps.preprocess import c_preprocessor, fortran_preprocessor
 from fab.util import common_arg_parser
 
 

--- a/run_configs/jules/build_jules.py
+++ b/run_configs/jules/build_jules.py
@@ -10,13 +10,13 @@ import os
 from fab.build_config import BuildConfig
 from fab.steps.analyse import Analyse
 from fab.steps.archive_objects import ArchiveObjects
-from fab.steps.compile_fortran import CompileFortran, get_fortran_compiler
+from fab.steps.compile_fortran import CompileFortran
 from fab.steps.find_source_files import FindSourceFiles, Exclude
 from fab.steps.grab import GrabFcm, GrabPreBuild
 from fab.steps.link import LinkExe
 from fab.steps.preprocess import fortran_preprocessor
 from fab.steps.root_inc_files import RootIncFiles
-from fab.util import common_arg_parser
+from fab.util import common_arg_parser, get_tool
 
 logger = logging.getLogger('fab')
 
@@ -24,7 +24,7 @@ logger = logging.getLogger('fab')
 def jules_config(revision=None, compiler=None, two_stage=False):
 
     # We want a separate project folder for each compiler. Find out which compiler we'll be using.
-    compiler, _ = get_fortran_compiler()
+    compiler, _ = get_tool(os.getenv('FC'))
     config = BuildConfig(project_label=f'jules {revision} {compiler} {int(two_stage)+1}stage')
 
     logger.info(f'building jules {config.project_label}')

--- a/run_configs/jules/build_jules.py
+++ b/run_configs/jules/build_jules.py
@@ -10,7 +10,7 @@ import os
 from fab.build_config import BuildConfig
 from fab.steps.analyse import Analyse
 from fab.steps.archive_objects import ArchiveObjects
-from fab.steps.compile_fortran import CompileFortran, get_compiler
+from fab.steps.compile_fortran import CompileFortran, get_fortran_compiler
 from fab.steps.find_source_files import FindSourceFiles, Exclude
 from fab.steps.grab import GrabFcm, GrabPreBuild
 from fab.steps.link import LinkExe
@@ -24,7 +24,7 @@ logger = logging.getLogger('fab')
 def jules_config(revision=None, compiler=None, two_stage=False):
 
     # We want a separate project folder for each compiler. Find out which compiler we'll be using.
-    compiler, _ = get_compiler()
+    compiler, _ = get_fortran_compiler()
     config = BuildConfig(project_label=f'jules {revision} {compiler} {int(two_stage)+1}stage')
 
     logger.info(f'building jules {config.project_label}')

--- a/run_configs/jules/build_jules.py
+++ b/run_configs/jules/build_jules.py
@@ -10,13 +10,13 @@ import os
 from fab.build_config import BuildConfig
 from fab.steps.analyse import Analyse
 from fab.steps.archive_objects import ArchiveObjects
-from fab.steps.compile_fortran import CompileFortran
+from fab.steps.compile_fortran import CompileFortran, get_fortran_compiler
 from fab.steps.find_source_files import FindSourceFiles, Exclude
 from fab.steps.grab import GrabFcm, GrabPreBuild
 from fab.steps.link import LinkExe
 from fab.steps.preprocess import fortran_preprocessor
 from fab.steps.root_inc_files import RootIncFiles
-from fab.util import common_arg_parser, get_tool
+from fab.util import common_arg_parser
 
 logger = logging.getLogger('fab')
 
@@ -24,7 +24,7 @@ logger = logging.getLogger('fab')
 def jules_config(revision=None, compiler=None, two_stage=False):
 
     # We want a separate project folder for each compiler. Find out which compiler we'll be using.
-    compiler, _ = get_tool(os.getenv('FC'))
+    compiler, _ = get_fortran_compiler(compiler)
     config = BuildConfig(project_label=f'jules {revision} {compiler} {int(two_stage)+1}stage')
 
     logger.info(f'building jules {config.project_label}')

--- a/run_configs/lfric/atm.py
+++ b/run_configs/lfric/atm.py
@@ -7,7 +7,7 @@ from fab.steps.analyse import Analyse
 from fab.steps.archive_objects import ArchiveObjects
 from fab.steps.c_pragma_injector import CPragmaInjector
 from fab.steps.compile_c import CompileC
-from fab.steps.compile_fortran import CompileFortran, get_compiler
+from fab.steps.compile_fortran import CompileFortran, get_fortran_compiler
 from fab.steps.grab import GrabFolder, GrabFcm
 from fab.steps.link import LinkExe
 from fab.steps.preprocess import fortran_preprocessor, c_preprocessor
@@ -27,7 +27,7 @@ def atm_config(two_stage=False, opt='Og'):
     gpl_utils_source = gpl_utils_source_config().source_root / 'gpl_utils'
 
     # We want a separate project folder for each compiler. Find out which compiler we'll be using.
-    compiler, _ = get_compiler()
+    compiler, _ = get_fortran_compiler()
 
     config = BuildConfig(
         project_label=f'atm {compiler} {opt} {int(two_stage)+1}stage',

--- a/run_configs/lfric/atm.py
+++ b/run_configs/lfric/atm.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import logging
+import os
 from argparse import ArgumentParser
 
 from fab.build_config import BuildConfig, AddFlags
@@ -7,12 +8,14 @@ from fab.steps.analyse import Analyse
 from fab.steps.archive_objects import ArchiveObjects
 from fab.steps.c_pragma_injector import CPragmaInjector
 from fab.steps.compile_c import CompileC
-from fab.steps.compile_fortran import CompileFortran, get_fortran_compiler
+from fab.steps.compile_fortran import CompileFortran
 from fab.steps.grab import GrabFolder, GrabFcm
 from fab.steps.link import LinkExe
 from fab.steps.preprocess import fortran_preprocessor, c_preprocessor
 from fab.steps.root_inc_files import RootIncFiles
 from fab.steps.find_source_files import FindSourceFiles, Exclude, Include
+from fab.util import get_tool
+
 from grab_lfric import lfric_source_config, gpl_utils_source_config
 from lfric_common import Configurator, FparserWorkaround_StopConcatenation, psyclone_preprocessor, Psyclone
 
@@ -27,7 +30,7 @@ def atm_config(two_stage=False, opt='Og'):
     gpl_utils_source = gpl_utils_source_config().source_root / 'gpl_utils'
 
     # We want a separate project folder for each compiler. Find out which compiler we'll be using.
-    compiler, _ = get_fortran_compiler()
+    compiler, _ = get_tool(os.getenv('FC'))
 
     config = BuildConfig(
         project_label=f'atm {compiler} {opt} {int(two_stage)+1}stage',

--- a/run_configs/lfric/atm.py
+++ b/run_configs/lfric/atm.py
@@ -8,13 +8,12 @@ from fab.steps.analyse import Analyse
 from fab.steps.archive_objects import ArchiveObjects
 from fab.steps.c_pragma_injector import CPragmaInjector
 from fab.steps.compile_c import CompileC
-from fab.steps.compile_fortran import CompileFortran
+from fab.steps.compile_fortran import CompileFortran, get_fortran_compiler
 from fab.steps.grab import GrabFolder, GrabFcm
 from fab.steps.link import LinkExe
 from fab.steps.preprocess import fortran_preprocessor, c_preprocessor
 from fab.steps.root_inc_files import RootIncFiles
 from fab.steps.find_source_files import FindSourceFiles, Exclude, Include
-from fab.util import get_tool
 
 from grab_lfric import lfric_source_config, gpl_utils_source_config
 from lfric_common import Configurator, FparserWorkaround_StopConcatenation, psyclone_preprocessor, Psyclone
@@ -30,7 +29,7 @@ def atm_config(two_stage=False, opt='Og'):
     gpl_utils_source = gpl_utils_source_config().source_root / 'gpl_utils'
 
     # We want a separate project folder for each compiler. Find out which compiler we'll be using.
-    compiler, _ = get_tool(os.getenv('FC'))
+    compiler, _ = get_fortran_compiler()
 
     config = BuildConfig(
         project_label=f'atm {compiler} {opt} {int(two_stage)+1}stage',

--- a/run_configs/lfric/atm.py
+++ b/run_configs/lfric/atm.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 import logging
-import os
 from argparse import ArgumentParser
 
 from fab.build_config import BuildConfig, AddFlags

--- a/run_configs/lfric/gungho.py
+++ b/run_configs/lfric/gungho.py
@@ -5,19 +5,16 @@
 #  which you should have received as part of this distribution
 # ##############################################################################
 import logging
-import os
 from argparse import ArgumentParser
-
 
 from fab.build_config import BuildConfig
 from fab.steps.analyse import Analyse
 from fab.steps.archive_objects import ArchiveObjects
-from fab.steps.compile_fortran import CompileFortran
+from fab.steps.compile_fortran import CompileFortran, get_fortran_compiler
 from fab.steps.grab import GrabFolder
 from fab.steps.link import LinkExe
 from fab.steps.preprocess import fortran_preprocessor
 from fab.steps.find_source_files import FindSourceFiles, Exclude
-from fab.util import get_tool
 
 from grab_lfric import lfric_source_config, gpl_utils_source_config
 from lfric_common import Configurator, FparserWorkaround_StopConcatenation, psyclone_preprocessor, Psyclone
@@ -33,7 +30,7 @@ def gungho_config(two_stage=False, opt='Og'):
     gpl_utils_source = gpl_utils_source_config().source_root / 'gpl_utils'
 
     # We want a separate project folder for each compiler. Find out which compiler we'll be using.
-    compiler, _ = get_tool(os.getenv('FC'))
+    compiler, _ = get_fortran_compiler()
 
     config = BuildConfig(
         project_label=f'gungho {compiler} {opt} {int(two_stage)+1}stage',

--- a/run_configs/lfric/gungho.py
+++ b/run_configs/lfric/gungho.py
@@ -10,7 +10,7 @@ from argparse import ArgumentParser
 from fab.build_config import BuildConfig
 from fab.steps.analyse import Analyse
 from fab.steps.archive_objects import ArchiveObjects
-from fab.steps.compile_fortran import CompileFortran, get_compiler
+from fab.steps.compile_fortran import CompileFortran, get_fortran_compiler
 from fab.steps.grab import GrabFolder
 from fab.steps.link import LinkExe
 from fab.steps.preprocess import fortran_preprocessor
@@ -29,7 +29,7 @@ def gungho_config(two_stage=False, opt='Og'):
     gpl_utils_source = gpl_utils_source_config().source_root / 'gpl_utils'
 
     # We want a separate project folder for each compiler. Find out which compiler we'll be using.
-    compiler, _ = get_compiler()
+    compiler, _ = get_fortran_compiler()
 
     config = BuildConfig(
         project_label=f'gungho {compiler} {opt} {int(two_stage)+1}stage',

--- a/run_configs/lfric/gungho.py
+++ b/run_configs/lfric/gungho.py
@@ -5,16 +5,20 @@
 #  which you should have received as part of this distribution
 # ##############################################################################
 import logging
+import os
 from argparse import ArgumentParser
+
 
 from fab.build_config import BuildConfig
 from fab.steps.analyse import Analyse
 from fab.steps.archive_objects import ArchiveObjects
-from fab.steps.compile_fortran import CompileFortran, get_fortran_compiler
+from fab.steps.compile_fortran import CompileFortran
 from fab.steps.grab import GrabFolder
 from fab.steps.link import LinkExe
 from fab.steps.preprocess import fortran_preprocessor
 from fab.steps.find_source_files import FindSourceFiles, Exclude
+from fab.util import get_tool
+
 from grab_lfric import lfric_source_config, gpl_utils_source_config
 from lfric_common import Configurator, FparserWorkaround_StopConcatenation, psyclone_preprocessor, Psyclone
 
@@ -29,7 +33,7 @@ def gungho_config(two_stage=False, opt='Og'):
     gpl_utils_source = gpl_utils_source_config().source_root / 'gpl_utils'
 
     # We want a separate project folder for each compiler. Find out which compiler we'll be using.
-    compiler, _ = get_fortran_compiler()
+    compiler, _ = get_tool(os.getenv('FC'))
 
     config = BuildConfig(
         project_label=f'gungho {compiler} {opt} {int(two_stage)+1}stage',

--- a/run_configs/lfric/mesh_tools.py
+++ b/run_configs/lfric/mesh_tools.py
@@ -1,17 +1,14 @@
 #!/usr/bin/env python3
-import os
 from argparse import ArgumentParser
-
 
 from fab.build_config import BuildConfig
 from fab.steps.analyse import Analyse
 from fab.steps.archive_objects import ArchiveObjects
-from fab.steps.compile_fortran import CompileFortran
+from fab.steps.compile_fortran import CompileFortran, get_fortran_compiler
 from fab.steps.grab import GrabFolder
 from fab.steps.link import LinkExe
 from fab.steps.preprocess import fortran_preprocessor
 from fab.steps.find_source_files import FindSourceFiles, Exclude
-from fab.util import get_tool
 
 from lfric_common import Configurator, psyclone_preprocessor, Psyclone, FparserWorkaround_StopConcatenation
 from grab_lfric import lfric_source_config, gpl_utils_source_config
@@ -22,7 +19,7 @@ def mesh_tools_config(two_stage=False, opt='Og'):
     gpl_utils_source = gpl_utils_source_config().source_root / 'gpl_utils'
 
     # We want a separate project folder for each compiler. Find out which compiler we'll be using.
-    compiler, _ = get_tool(os.getenv('FC'))
+    compiler, _ = get_fortran_compiler()
 
     config = BuildConfig(project_label=f'mesh tools {compiler} {opt} {int(two_stage)+1}stage')
     config.steps = [

--- a/run_configs/lfric/mesh_tools.py
+++ b/run_configs/lfric/mesh_tools.py
@@ -5,7 +5,7 @@ from fab.steps.archive_objects import ArchiveObjects
 
 from fab.build_config import BuildConfig
 from fab.steps.analyse import Analyse
-from fab.steps.compile_fortran import CompileFortran, get_compiler
+from fab.steps.compile_fortran import CompileFortran, get_fortran_compiler
 from fab.steps.grab import GrabFolder
 from fab.steps.link import LinkExe
 from fab.steps.preprocess import fortran_preprocessor
@@ -19,7 +19,7 @@ def mesh_tools_config(two_stage=False, opt='Og'):
     gpl_utils_source = gpl_utils_source_config().source_root / 'gpl_utils'
 
     # We want a separate project folder for each compiler. Find out which compiler we'll be using.
-    compiler, _ = get_compiler()
+    compiler, _ = get_fortran_compiler()
 
     config = BuildConfig(project_label=f'mesh tools {compiler} {opt} {int(two_stage)+1}stage')
     config.steps = [

--- a/run_configs/lfric/mesh_tools.py
+++ b/run_configs/lfric/mesh_tools.py
@@ -1,15 +1,18 @@
 #!/usr/bin/env python3
+import os
 from argparse import ArgumentParser
 
-from fab.steps.archive_objects import ArchiveObjects
 
 from fab.build_config import BuildConfig
 from fab.steps.analyse import Analyse
-from fab.steps.compile_fortran import CompileFortran, get_fortran_compiler
+from fab.steps.archive_objects import ArchiveObjects
+from fab.steps.compile_fortran import CompileFortran
 from fab.steps.grab import GrabFolder
 from fab.steps.link import LinkExe
 from fab.steps.preprocess import fortran_preprocessor
 from fab.steps.find_source_files import FindSourceFiles, Exclude
+from fab.util import get_tool
+
 from lfric_common import Configurator, psyclone_preprocessor, Psyclone, FparserWorkaround_StopConcatenation
 from grab_lfric import lfric_source_config, gpl_utils_source_config
 
@@ -19,7 +22,7 @@ def mesh_tools_config(two_stage=False, opt='Og'):
     gpl_utils_source = gpl_utils_source_config().source_root / 'gpl_utils'
 
     # We want a separate project folder for each compiler. Find out which compiler we'll be using.
-    compiler, _ = get_fortran_compiler()
+    compiler, _ = get_tool(os.getenv('FC'))
 
     config = BuildConfig(project_label=f'mesh tools {compiler} {opt} {int(two_stage)+1}stage')
     config.steps = [

--- a/run_configs/um/build_um.py
+++ b/run_configs/um/build_um.py
@@ -15,23 +15,21 @@ import warnings
 from argparse import ArgumentParser
 from pathlib import Path
 
-from fab.constants import PRAGMAD_C
-
 from fab.artefacts import CollectionGetter
 from fab.build_config import AddFlags, BuildConfig
+from fab.constants import PRAGMAD_C
 from fab.dep_tree import AnalysedFile
 from fab.steps import Step
 from fab.steps.analyse import Analyse
 from fab.steps.archive_objects import ArchiveObjects
 from fab.steps.c_pragma_injector import CPragmaInjector
 from fab.steps.compile_c import CompileC
-from fab.steps.compile_fortran import CompileFortran
+from fab.steps.compile_fortran import CompileFortran, get_fortran_compiler
 from fab.steps.grab import GrabFcm
 from fab.steps.link import LinkExe
 from fab.steps.preprocess import c_preprocessor, fortran_preprocessor
 from fab.steps.root_inc_files import RootIncFiles
 from fab.steps.find_source_files import FindSourceFiles, Exclude, Include
-from fab.util import get_tool
 
 logger = logging.getLogger('fab')
 
@@ -43,7 +41,7 @@ def um_atmos_safe_config(revision, two_stage=False, opt='Og'):
     um_revision = revision.replace('vn', 'um')
 
     # We want a separate project folder for each compiler. Find out which compiler we'll be using.
-    compiler, _ = get_tool(os.getenv('FC'))
+    compiler, _ = get_fortran_compiler()
     if compiler == 'gfortran':
         compiler_specific_flags = ['-fdefault-integer-8', '-fdefault-real-8', '-fdefault-double-8']
     else:

--- a/run_configs/um/build_um.py
+++ b/run_configs/um/build_um.py
@@ -25,12 +25,13 @@ from fab.steps.analyse import Analyse
 from fab.steps.archive_objects import ArchiveObjects
 from fab.steps.c_pragma_injector import CPragmaInjector
 from fab.steps.compile_c import CompileC
-from fab.steps.compile_fortran import CompileFortran, get_compiler
+from fab.steps.compile_fortran import CompileFortran
 from fab.steps.grab import GrabFcm
 from fab.steps.link import LinkExe
 from fab.steps.preprocess import c_preprocessor, fortran_preprocessor
 from fab.steps.root_inc_files import RootIncFiles
 from fab.steps.find_source_files import FindSourceFiles, Exclude, Include
+from fab.util import get_tool
 
 logger = logging.getLogger('fab')
 
@@ -42,7 +43,7 @@ def um_atmos_safe_config(revision, two_stage=False, opt='Og'):
     um_revision = revision.replace('vn', 'um')
 
     # We want a separate project folder for each compiler. Find out which compiler we'll be using.
-    compiler, _ = get_compiler()
+    compiler, _ = get_tool(os.getenv('FC'))
     if compiler == 'gfortran':
         compiler_specific_flags = ['-fdefault-integer-8', '-fdefault-real-8', '-fdefault-double-8']
     else:

--- a/source/fab/steps/compile_c.py
+++ b/source/fab/steps/compile_c.py
@@ -56,7 +56,7 @@ class CompileC(Step):
         """
         super().__init__(name=name)
 
-        self.compiler, compiler_flags = get_tool(compiler or os.getenv('CC', 'gcc -c'))
+        self.compiler, compiler_flags = get_tool(compiler or os.getenv('CC', 'gcc -c'))  # type: ignore
         self.compiler_version = get_compiler_version(self.compiler)
         logger.info(f'c compiler is {self.compiler} {self.compiler_version}')
 

--- a/source/fab/steps/compile_c.py
+++ b/source/fab/steps/compile_c.py
@@ -80,8 +80,6 @@ class CompileC(Step):
         """
         super().run(artefact_store, config)
 
-        logger.setLevel(logging.DEBUG)
-
         # gather all the source to compile, for all build trees, into one big lump
         build_lists: Dict = self.source_getter(artefact_store)
         to_compile = sum(build_lists.values(), [])
@@ -100,8 +98,6 @@ class CompileC(Step):
         for root, source_files in build_lists.items():
             new_objects = [lookup[af.fpath].output_fpath for af in source_files]
             target_object_files[root].update(new_objects)
-
-        logger.setLevel(logging.INFO)
 
     def _compile_file(self, analysed_file: AnalysedFile):
 

--- a/source/fab/steps/compile_c.py
+++ b/source/fab/steps/compile_c.py
@@ -9,6 +9,7 @@ C file compilation.
 """
 import logging
 import os
+import warnings
 import zlib
 from collections import defaultdict
 from typing import List, Dict, Optional
@@ -62,6 +63,12 @@ class CompileC(Step):
 
         env_flags = os.getenv('CFLAGS', '').split()
         common_flags = compiler_flags + env_flags + (common_flags or [])
+
+        # make sure we have a -c
+        # todo: c compiler awareness, like we have with fortran?
+        if '-c' not in common_flags:
+            warnings.warn("Adding '-c' to C compiler flags")
+            common_flags = ['-c'] + common_flags
 
         self.flags = FlagsConfig(common_flags=common_flags, path_flags=path_flags)
         self.source_getter = source or DEFAULT_SOURCE_GETTER

--- a/source/fab/steps/compile_c.py
+++ b/source/fab/steps/compile_c.py
@@ -56,7 +56,7 @@ class CompileC(Step):
         """
         super().__init__(name=name)
 
-        self.compiler, compiler_flags = get_tool(compiler or os.getenv('CC'))
+        self.compiler, compiler_flags = get_tool(compiler or os.getenv('CC', 'gcc -c'))
         self.compiler_version = get_compiler_version(self.compiler)
         logger.info(f'c compiler is {self.compiler} {self.compiler_version}')
 
@@ -80,6 +80,8 @@ class CompileC(Step):
         """
         super().run(artefact_store, config)
 
+        logger.setLevel(logging.DEBUG)
+
         # gather all the source to compile, for all build trees, into one big lump
         build_lists: Dict = self.source_getter(artefact_store)
         to_compile = sum(build_lists.values(), [])
@@ -98,6 +100,8 @@ class CompileC(Step):
         for root, source_files in build_lists.items():
             new_objects = [lookup[af.fpath].output_fpath for af in source_files]
             target_object_files[root].update(new_objects)
+
+        logger.setLevel(logging.INFO)
 
     def _compile_file(self, analysed_file: AnalysedFile):
 

--- a/source/fab/steps/compile_fortran.py
+++ b/source/fab/steps/compile_fortran.py
@@ -62,7 +62,7 @@ class CompileFortran(Step):
         super().__init__(name=name)
 
         # Command line tools are sometimes specified with flags attached.
-        self.compiler, compiler_flags = get_tool(compiler or os.getenv('FC', ''))  # type: ignore
+        self.compiler, compiler_flags = get_fortran_compiler(compiler)
         self.compiler_version = get_compiler_version(self.compiler)
         logger.info(f'fortran compiler is {self.compiler} {self.compiler_version}')
 
@@ -327,6 +327,20 @@ class CompileFortran(Step):
             group=metric_name,
             name=str(analysed_file.fpath),
             value={'time_taken': timer.taken, 'start': timer.start})
+
+
+def get_fortran_compiler(compiler: Optional[str] = None):
+    """
+    Get the fortran compiler specified by the `$FC` environment variable,
+    or overridden by the optional `compiler` argument.
+
+    Separates the tool and flags for the sort of value we see in environment variables, e.g. `gfortran -c`.
+
+    :param compiler:
+        Use this string instead of the $FC environment variable.
+
+    """
+    return get_tool(compiler or os.getenv('FC', ''))
 
 
 def get_mod_hashes(analysed_files: Set[AnalysedFile], config) -> Dict[str, int]:

--- a/source/fab/steps/compile_fortran.py
+++ b/source/fab/steps/compile_fortran.py
@@ -13,7 +13,7 @@ import shutil
 import zlib
 from collections import defaultdict
 from pathlib import Path
-from typing import List, Set, Dict, Tuple, Optional
+from typing import List, Set, Dict, Optional
 
 from fab.artefacts import ArtefactsGetter, FilterBuildTrees
 from fab.build_config import FlagsConfig

--- a/source/fab/steps/compile_fortran.py
+++ b/source/fab/steps/compile_fortran.py
@@ -340,7 +340,7 @@ def get_fortran_compiler(compiler: Optional[str] = None):
         Use this string instead of the $FC environment variable.
 
     """
-    return get_tool(compiler or os.getenv('FC', ''))
+    return get_tool(compiler or os.getenv('FC', ''))  # type: ignore
 
 
 def get_mod_hashes(analysed_files: Set[AnalysedFile], config) -> Dict[str, int]:

--- a/source/fab/steps/compile_fortran.py
+++ b/source/fab/steps/compile_fortran.py
@@ -62,7 +62,7 @@ class CompileFortran(Step):
         super().__init__(name=name)
 
         # Command line tools are sometimes specified with flags attached.
-        self.compiler, compiler_flags = get_tool(compiler or os.getenv('FC'))
+        self.compiler, compiler_flags = get_tool(compiler or os.getenv('FC', ''))  # type: ignore
         self.compiler_version = get_compiler_version(self.compiler)
         logger.info(f'fortran compiler is {self.compiler} {self.compiler_version}')
 

--- a/source/fab/util.py
+++ b/source/fab/util.py
@@ -18,7 +18,7 @@ from argparse import ArgumentParser
 from collections import namedtuple, defaultdict
 from pathlib import Path
 from time import perf_counter
-from typing import Iterator, Iterable, Optional, Set, Dict, List
+from typing import Iterator, Iterable, Optional, Set, Dict, List, Tuple
 
 from fab.tools import COMPILERS
 
@@ -327,3 +327,62 @@ def common_arg_parser():
     arg_parser.add_argument('--two-stage', action='store_true')
 
     return arg_parser
+
+
+def get_tool(tool_str: str = '') -> Tuple[str, List[str]]:
+    """
+    Get the compiler, preprocessor, etc, from the given string.
+
+    Separate the tool and flags for the sort of value we see in environment variables, e.g. `gfortran -c`.
+
+    Returns the tool and a list of flags.
+
+    :param env_var:
+        The environment variable from which to find the tool.
+
+    """
+    tool_split = tool_str.split()
+    if not tool_split:
+        raise ValueError(f"Tool not specified in '{tool_str}'. Cannot continue.")
+    return tool_split[0], tool_split[1:]
+
+
+# todo: add more compilers and test with more versions of compilers
+def get_compiler_version(compiler: str) -> str:
+    """
+    Try to get the version of the given compiler.
+
+    Expects a version in a certain part of the --version output,
+    which must adhere to the n.n.n format, with at least 2 parts.
+
+    Returns a version string, e.g '6.10.1', or empty string.
+
+    """
+    try:
+        res = run_command([compiler, '--version'])
+    except FileNotFoundError:
+        raise ValueError(f'Compiler not found: {compiler}')
+    except RuntimeError as err:
+        logger.warning(f"Error asking for version of compiler '{compiler}': {err}")
+        return ''
+
+    # Pull the version string from the command output.
+    # All the versions of gfortran and ifort we've tried follow the same pattern, it's after a ")".
+    try:
+        version = res.split(')')[1].split()[0]
+    except IndexError:
+        logger.warning(f"Unexpected version response from compiler '{compiler}': {res}")
+        return ''
+
+    # expect major.minor[.patch, ...]
+    # validate - this may be overkill
+    split = version.split('.')
+    if len(split) < 2:
+        logger.warning(f"unhandled compiler version format for compiler '{compiler}' is not <n.n[.n, ...]>: {version}")
+        return ''
+
+    # todo: do we care if the parts are integers? Not all will be, but perhaps major and minor?
+
+    logger.info(f'Found compiler version for {compiler} = {version}')
+
+    return version

--- a/source/fab/util.py
+++ b/source/fab/util.py
@@ -357,6 +357,9 @@ def get_compiler_version(compiler: str) -> str:
 
     Returns a version string, e.g '6.10.1', or empty string.
 
+    :param compiler:
+        The command line tool for which we want a version.
+
     """
     try:
         res = run_command([compiler, '--version'])

--- a/tests/unit_tests/steps/test_compile_c.py
+++ b/tests/unit_tests/steps/test_compile_c.py
@@ -11,30 +11,41 @@ from fab.dep_tree import AnalysedFile
 from fab.steps.compile_c import CompileC
 
 
+@pytest.fixture
+def compiler():
+    with mock.patch.dict(os.environ, {'CC': 'foo_cc', 'CFLAGS': '-Denv_flag'}):
+        with mock.patch('fab.steps.compile_c.get_compiler_version', return_value='1.2.3'):
+            compiler = CompileC(
+                path_flags=[AddFlags(match='foo/src/*', flags=['-I', 'foo/include', '-Dhello'])])
+    return compiler
+
+
+@pytest.fixture
+def content(tmp_path, compiler):
+    config = BuildConfig('proj', source_root=Path('foo/src'), multiprocessing=False, fab_workspace=tmp_path)
+    analysed_file = AnalysedFile(fpath=Path('foo/src/foo.c'), file_hash=0)
+    artefact_store = {BUILD_TREES: {None: {analysed_file.fpath: analysed_file}}}
+    expect_hash = 9120682468
+    return config, artefact_store, compiler, analysed_file, expect_hash
+
+
 # This is more of an integration test than a unit test
 class Test_CompileC(object):
 
-    def test_vanilla(self, tmp_path):
+    def test_vanilla(self, content):
         # ensure the command is formed correctly
-
-        # prepare a compiler step
-        config = BuildConfig('proj', source_root=Path('foo/src'), multiprocessing=False, fab_workspace=tmp_path)
-        analysed_file = AnalysedFile(fpath=Path('foo/src/foo.c'), file_hash=0)
-        artefact_store = {BUILD_TREES: {None: {analysed_file.fpath: analysed_file}}}
-        with mock.patch.dict(os.environ, {'CFLAGS': ''}):
-            c_compiler = CompileC(path_flags=[
-                AddFlags(match='foo/src/*', flags=['-I', 'foo/include', '-Dhello'])])
+        config, artefact_store, compiler, analysed_file, expect_hash = content
 
         # run the step
         with mock.patch('fab.steps.compile_c.run_command') as mock_run_command:
             with mock.patch('fab.steps.compile_c.send_metric') as mock_send_metric:
                 with mock.patch('pathlib.Path.mkdir'):
-                    c_compiler.run(artefact_store=artefact_store, config=config)
+                    compiler.run(artefact_store=artefact_store, config=config)
 
         # ensure it made the correct command-line call from the child process
         mock_run_command.assert_called_with([
-            'gcc', '-c', '-I', 'foo/include', '-Dhello',
-            normpath('foo/src/foo.c'), '-o', str(config.prebuild_folder / 'foo.101ea42db.o'),
+            'foo_cc', '-c', '-Denv_flag', '-I', 'foo/include', '-Dhello',
+            normpath('foo/src/foo.c'), '-o', str(config.prebuild_folder / f'foo.{expect_hash:x}.o'),
         ])
 
         # ensure it sent a metric from the child process
@@ -42,23 +53,65 @@ class Test_CompileC(object):
 
         # ensure it created the correct artefact collection
         assert artefact_store[OBJECT_FILES] == {
-            None: {config.prebuild_folder / 'foo.101ea42db.o', }
+            None: {config.prebuild_folder / 'foo.21fa291e4.o', }
         }
 
-    def test_exception_handling(self):
-
-        # prepare a compiler step
-        config = BuildConfig('proj', source_root=Path('foo/src'), multiprocessing=False)
-        analysed_file = AnalysedFile(fpath=Path('foo/src/foo.c'), file_hash=0)
-        artefact_store = {BUILD_TREES: {None: {analysed_file.fpath: analysed_file}}}
-        c_compiler = CompileC()
+    def test_exception_handling(self, content):
+        config, artefact_store, compiler, _, _ = content
 
         # mock the run command to raise
         with pytest.raises(RuntimeError):
             with mock.patch('fab.steps.compile_c.run_command', side_effect=Exception):
                 with mock.patch('fab.steps.compile_c.send_metric') as mock_send_metric:
                     with mock.patch('pathlib.Path.mkdir'):
-                        c_compiler.run(artefact_store=artefact_store, config=config)
+                        compiler.run(artefact_store=artefact_store, config=config)
 
         # ensure no metric was sent from the child process
         mock_send_metric.assert_not_called()
+
+
+class Test_get_obj_combo_hash(object):
+
+    def test_vanilla(self, content):
+        config, artefact_store, compiler, analysed_file, expect_hash = content
+
+        flags = compiler.flags.flags_for_path(analysed_file.fpath, config)
+        result = compiler._get_obj_combo_hash(analysed_file, flags)
+
+        assert result == expect_hash
+
+    def test_change_file(self, content):
+        config, artefact_store, compiler, analysed_file, expect_hash = content
+        analysed_file._file_hash += 1
+
+        flags = compiler.flags.flags_for_path(analysed_file.fpath, config)
+        result = compiler._get_obj_combo_hash(analysed_file, flags)
+
+        assert result == expect_hash + 1
+
+    def test_change_flags(self, content):
+        config, artefact_store, compiler, analysed_file, expect_hash = content
+        compiler.flags.common_flags.append('-Dfoo')
+
+        flags = compiler.flags.flags_for_path(analysed_file.fpath, config)
+        result = compiler._get_obj_combo_hash(analysed_file, flags)
+
+        assert result != expect_hash
+
+    def test_change_compiler(self, content):
+        config, artefact_store, compiler, analysed_file, expect_hash = content
+        compiler.compiler = 'ooh_cc'
+
+        flags = compiler.flags.flags_for_path(analysed_file.fpath, config)
+        result = compiler._get_obj_combo_hash(analysed_file, flags)
+
+        assert result != expect_hash
+
+    def test_change_compiler_version(self, content):
+        config, artefact_store, compiler, analysed_file, expect_hash = content
+        compiler.compiler_version = '1.2.4'
+
+        flags = compiler.flags.flags_for_path(analysed_file.fpath, config)
+        result = compiler._get_obj_combo_hash(analysed_file, flags)
+
+        assert result != expect_hash

--- a/tests/unit_tests/steps/test_compile_c.py
+++ b/tests/unit_tests/steps/test_compile_c.py
@@ -12,18 +12,13 @@ from fab.steps.compile_c import CompileC
 
 
 @pytest.fixture
-def compiler():
-    with mock.patch.dict(os.environ, {'CC': 'foo_cc', 'CFLAGS': '-Denv_flag'}):
-        with mock.patch('fab.steps.compile_c.get_compiler_version', return_value='1.2.3'):
-            compiler = CompileC(
-                path_flags=[AddFlags(match='foo/src/*', flags=['-I', 'foo/include', '-Dhello'])])
-    return compiler
-
-
-@pytest.fixture
-def content(tmp_path, compiler):
+def content(tmp_path):
     config = BuildConfig('proj', source_root=Path('foo/src'), multiprocessing=False, fab_workspace=tmp_path)
     analysed_file = AnalysedFile(fpath=Path('foo/src/foo.c'), file_hash=0)
+    with mock.patch.dict(os.environ, {'CC': 'foo_cc', 'CFLAGS': '-Denv_flag'}):
+        with mock.patch('fab.steps.compile_c.get_compiler_version', return_value='1.2.3'):
+            compiler = CompileC(path_flags=[
+                AddFlags(match='foo/src/*', flags=['-I', 'foo/include', '-Dhello'])])
     artefact_store = {BUILD_TREES: {None: {analysed_file.fpath: analysed_file}}}
     expect_hash = 9120682468
     return config, artefact_store, compiler, analysed_file, expect_hash

--- a/tests/unit_tests/steps/test_compile_c.py
+++ b/tests/unit_tests/steps/test_compile_c.py
@@ -48,7 +48,7 @@ class Test_CompileC(object):
 
         # ensure it created the correct artefact collection
         assert artefact_store[OBJECT_FILES] == {
-            None: {config.prebuild_folder / 'foo.21fa291e4.o', }
+            None: {config.prebuild_folder / f'foo.{expect_hash:x}.o', }
         }
 
     def test_exception_handling(self, content):

--- a/tests/unit_tests/steps/test_compile_fortran.py
+++ b/tests/unit_tests/steps/test_compile_fortran.py
@@ -10,13 +10,13 @@ from fab.build_config import BuildConfig
 from fab.constants import BUILD_TREES, OBJECT_FILES
 
 from fab.dep_tree import AnalysedFile
-from fab.steps.compile_fortran import CompileFortran, get_fortran_compiler, get_compiler_version, get_mod_hashes
+from fab.steps.compile_fortran import CompileFortran, get_compiler_version, get_mod_hashes
 from fab.util import CompiledFile
 
 
 @pytest.fixture()
 def compiler():
-    with mock.patch('fab.steps.compile_fortran._get_compiler_version', return_value='1.2.3'):
+    with mock.patch('fab.steps.compile_fortran.get_compiler_version', return_value='1.2.3'):
         compiler = CompileFortran(compiler="foo_cc")
     return compiler
 
@@ -115,7 +115,7 @@ class Test_process_file(object):
 
     def content(self, flags=None):
 
-        with mock.patch('fab.steps.compile_fortran._get_compiler_version', return_value='1.2.3'):
+        with mock.patch('fab.steps.compile_fortran.get_compiler_version', return_value='1.2.3'):
             compiler = CompileFortran(compiler="foo_cc")
 
         flags = flags or ['flag1', 'flag2']
@@ -358,25 +358,16 @@ class test_constructor(object):
         assert cf.flags.common_flags == ['-c', '-J', '/mods']
 
 
-class test_get_compiler(object):
-
-    def test_without_flag(self):
-        assert get_fortran_compiler('gfortran') == ('gfortran', [])
-
-    def test_with_flag(self):
-        assert get_fortran_compiler('gfortran -c') == ('gfortran', ['-c'])
-
-
 class Test_get_compiler_version(object):
 
     def _check(self, full_version_string, expect):
-        with mock.patch('fab.steps.compile_fortran.run_command', return_value=full_version_string):
+        with mock.patch('fab.util.run_command', return_value=full_version_string):
             result = get_compiler_version(None)
         assert result == expect
 
     def test_command_failure(self):
         # if the command fails, we must return an empty string, not None, so it can still be hashed
-        with mock.patch('fab.steps.compile_fortran.run_command', side_effect=RuntimeError()):
+        with mock.patch('fab.util.run_command', side_effect=RuntimeError()):
             assert get_compiler_version(None) == '', 'expected empty string'
 
     def test_unknown_command_response(self):

--- a/tests/unit_tests/steps/test_compile_fortran.py
+++ b/tests/unit_tests/steps/test_compile_fortran.py
@@ -10,7 +10,7 @@ from fab.build_config import BuildConfig
 from fab.constants import BUILD_TREES, OBJECT_FILES
 
 from fab.dep_tree import AnalysedFile
-from fab.steps.compile_fortran import CompileFortran, get_compiler, _get_compiler_version, get_mod_hashes
+from fab.steps.compile_fortran import CompileFortran, get_fortran_compiler, get_compiler_version, get_mod_hashes
 from fab.util import CompiledFile
 
 
@@ -361,23 +361,23 @@ class test_constructor(object):
 class test_get_compiler(object):
 
     def test_without_flag(self):
-        assert get_compiler('gfortran') == ('gfortran', [])
+        assert get_fortran_compiler('gfortran') == ('gfortran', [])
 
     def test_with_flag(self):
-        assert get_compiler('gfortran -c') == ('gfortran', ['-c'])
+        assert get_fortran_compiler('gfortran -c') == ('gfortran', ['-c'])
 
 
 class Test_get_compiler_version(object):
 
     def _check(self, full_version_string, expect):
         with mock.patch('fab.steps.compile_fortran.run_command', return_value=full_version_string):
-            result = _get_compiler_version(None)
+            result = get_compiler_version(None)
         assert result == expect
 
     def test_command_failure(self):
         # if the command fails, we must return an empty string, not None, so it can still be hashed
         with mock.patch('fab.steps.compile_fortran.run_command', side_effect=RuntimeError()):
-            assert _get_compiler_version(None) == '', 'expected empty string'
+            assert get_compiler_version(None) == '', 'expected empty string'
 
     def test_unknown_command_response(self):
         # if the full version output is in an unknown format, we must return an empty string

--- a/tests/unit_tests/steps/test_compile_fortran.py
+++ b/tests/unit_tests/steps/test_compile_fortran.py
@@ -8,7 +8,6 @@ import pytest
 
 from fab.build_config import BuildConfig
 from fab.constants import BUILD_TREES, OBJECT_FILES
-
 from fab.dep_tree import AnalysedFile
 from fab.steps.compile_fortran import CompileFortran, get_compiler_version, get_mod_hashes
 from fab.util import CompiledFile

--- a/tests/unit_tests/test_build_config.py
+++ b/tests/unit_tests/test_build_config.py
@@ -22,7 +22,7 @@ class TestBuildConfig(object):
 
         mock_source = {None: [AnalysedFile('foo.f', file_hash=0)]}
 
-        with mock.patch('fab.steps.compile_fortran._get_compiler_version', return_value='1.2.3'):
+        with mock.patch('fab.steps.compile_fortran.get_compiler_version', return_value='1.2.3'):
             with mock.patch('fab.steps.compile_fortran.DEFAULT_SOURCE_GETTER', return_value=mock_source):
                 config = BuildConfig('proj', fab_workspace=tmp_path, multiprocessing=False, steps=[
                     CompileFortran(compiler='foofc')])

--- a/tests/unit_tests/test_util.py
+++ b/tests/unit_tests/test_util.py
@@ -96,3 +96,12 @@ class Test_remove_managed_flags(object):
         flags = ['--foo', '-J', 'nope', '--bar']
         result = remove_managed_flags('foofc', flags)
         assert result == ['--foo', '-J', 'nope', '--bar']
+
+
+class test_get_tool(object):
+
+    def test_without_flag(self):
+        assert get_tool('gfortran') == ('gfortran', [])
+
+    def test_with_flag(self):
+        assert get_tool('gfortran -c') == ('gfortran', ['-c'])

--- a/tests/unit_tests/test_util.py
+++ b/tests/unit_tests/test_util.py
@@ -4,7 +4,7 @@ from unittest import mock
 import pytest
 
 from fab.artefacts import CollectionConcat, SuffixFilter
-from fab.util import run_command, flags_checksum, remove_managed_flags
+from fab.util import run_command, flags_checksum, remove_managed_flags, get_tool
 from fab.util import suffix_filter
 
 


### PR DESCRIPTION
Incremental C building.
- Function to get C compiler largely the same as for Fortran, so now in `util.get_tool()`.
- Added `get_fortran_compiler()` for user convenience.
- Added `-c` if missing, with warning. This seems like a step towards C compiler awareness, like we have with Fortran.
- Moved `get_compiler_version()` to util because C compiler version format matches Fortran.

todo:
 - [ ] coordinate with #153 to register incremental c artefacts as "current"

Closes #174 