### PR TITLE
180 disable c without clang

### DIFF
--- a/source/fab/tasks/c.py
+++ b/source/fab/tasks/c.py
@@ -6,11 +6,16 @@ C language handling classes.
 
 """
 import logging
+import warnings
 from collections import deque
 from pathlib import Path
 from typing import List, Optional
 
-import clang.cindex  # type: ignore
+try:
+    import clang  # type: ignore
+    import clang.cindex  # type: ignore
+except ImportError:
+    clang = None
 
 from fab.dep_tree import AnalysedFile
 from fab.util import log_or_dot, file_checksum
@@ -83,6 +88,12 @@ class CAnalyser(object):
             return None
 
     def run(self, fpath: Path):
+
+        if not clang:
+            msg = 'clang not available, C analysis disabled'
+            warnings.warn(msg, ImportWarning)
+            return ImportWarning(msg)
+
         log_or_dot(logger, f"analysing {fpath}")
 
         # do we already have analysis results for this file?

--- a/tests/unit_tests/tasks/c/test_c_analyser.py
+++ b/tests/unit_tests/tasks/c/test_c_analyser.py
@@ -159,3 +159,13 @@ class Test_process_symbol_dependency(object):
         analyser._process_symbol_dependency(analysed_file, node, usr_symbols)
 
         return analysed_file
+
+
+def test_clang_disable():
+
+    with mock.patch('fab.tasks.c.clang', None):
+        with mock.patch('fab.tasks.c.file_checksum') as mock_file_checksum:
+            result = CAnalyser().run(Path(__file__).parent / "test_c_analyser.c")
+
+    assert type(result) == ImportWarning
+    mock_file_checksum.assert_not_called()


### PR DESCRIPTION
If clang is not available, don't attempt to do anything in the c analyser code. Warn but don't fail.

Note: We could raise an exception but we've already seen config sharing which includes c steps when there's no c code. In this case  it would seem better to just notify but continue.

Resolves #180