### PR TITLE
Ifort um

### DIFF
--- a/run_configs/build_all.py
+++ b/run_configs/build_all.py
@@ -35,7 +35,7 @@ def build_all():
     ]
 
     # skip these for now, until we configure them to build again
-    compiler_skip = {'gfortran': [], 'ifort': ['build_um.py', 'atm.py']}
+    compiler_skip = {'gfortran': [], 'ifort': ['atm.py']}
     skip = compiler_skip[compiler]
 
     for script in scripts:

--- a/run_configs/um/build_um.py
+++ b/run_configs/um/build_um.py
@@ -45,7 +45,7 @@ def um_atmos_safe_config(revision, two_stage=False):
     compiler, _ = get_compiler()
     if compiler == 'gfortran':
         compiler_specific_flags = ['-fdefault-integer-8', '-fdefault-real-8', '-fdefault-double-8']
-    else:
+    elif compiler == 'ifort':
         # compiler_specific_flags = ['-r8']
         compiler_specific_flags = [
             '-i8', '-r8', '-mcmodel=medium',
@@ -57,6 +57,8 @@ def um_atmos_safe_config(revision, two_stage=False):
             '-fpic',
             '-assume nosource_include,protect_parens',
         ]
+    else:
+        compiler_specific_flags = []
 
     config = BuildConfig(
         project_label=f'um atmos safe {revision} {compiler} {int(two_stage)+1}stage',

--- a/source/fab/build_config.py
+++ b/source/fab/build_config.py
@@ -76,8 +76,8 @@ class BuildConfig(object):
                 logger.info(f"FAB_WORKSPACE not set, defaulting to {fab_workspace}")
         logger.info(f"fab workspace is {fab_workspace}")
 
-        self.project_workspace = fab_workspace / self.project_label
-        self.metrics_folder = self.project_workspace / 'metrics' / self.project_label
+        self.project_workspace: Path = fab_workspace / self.project_label
+        self.metrics_folder: Path = self.project_workspace / 'metrics' / self.project_label
 
         # source config
         self.source_root: Path = source_root or self.project_workspace / SOURCE_ROOT
@@ -106,6 +106,8 @@ class BuildConfig(object):
         if verbose:
             logging.getLogger('fab').setLevel(logging.DEBUG)
 
+        self._init_logging()
+
         # runtime
         self._artefact_store: Optional[Dict[str, Any]] = None
 
@@ -132,7 +134,7 @@ class BuildConfig(object):
         self.build_output.mkdir(parents=True, exist_ok=True)
         self.prebuild_folder.mkdir(parents=True, exist_ok=True)
 
-        self._init_logging()
+        # self._init_logging()
         init_metrics(metrics_folder=self.metrics_folder)
 
         self._artefact_store = dict()
@@ -152,6 +154,7 @@ class BuildConfig(object):
 
     def _init_logging(self):
         # add a file logger for our run
+        self.project_workspace.mkdir(parents=True, exist_ok=True)
         log_file_handler = RotatingFileHandler(self.project_workspace / 'log.txt', backupCount=5, delay=True)
         log_file_handler.doRollover()
         logging.getLogger('fab').addHandler(log_file_handler)

--- a/source/fab/build_config.py
+++ b/source/fab/build_config.py
@@ -11,6 +11,7 @@ import getpass
 import logging
 import os
 import sys
+import warnings
 from datetime import datetime
 from fnmatch import fnmatch
 from logging.handlers import RotatingFileHandler
@@ -106,8 +107,6 @@ class BuildConfig(object):
         if verbose:
             logging.getLogger('fab').setLevel(logging.DEBUG)
 
-        self._init_logging()
-
         # runtime
         self._artefact_store: Optional[Dict[str, Any]] = None
 
@@ -134,7 +133,7 @@ class BuildConfig(object):
         self.build_output.mkdir(parents=True, exist_ok=True)
         self.prebuild_folder.mkdir(parents=True, exist_ok=True)
 
-        # self._init_logging()
+        self._init_logging()
         init_metrics(metrics_folder=self.metrics_folder)
 
         self._artefact_store = dict()
@@ -170,7 +169,8 @@ class BuildConfig(object):
         # remove our file logger
         fab_logger = logging.getLogger('fab')
         log_file_handlers = list(by_type(fab_logger.handlers, RotatingFileHandler))
-        assert len(log_file_handlers) == 1
+        if len(log_file_handlers) != 1:
+            warnings.warn(f'expected to find 1 RotatingFileHandler for removal, found {len(log_file_handlers)}')
         fab_logger.removeHandler(log_file_handlers[0])
 
     def _finalise_metrics(self, start_time, steps_timer):

--- a/source/fab/steps/compile_fortran.py
+++ b/source/fab/steps/compile_fortran.py
@@ -65,7 +65,6 @@ class CompileFortran(Step):
 
         # Command line tools are sometimes specified with flags attached.
         self.compiler, compiler_flags = get_compiler(compiler)
-        logger.info(f'fortran compiler is {self.compiler}')
 
         # collate the flags
         env_flags = os.getenv('FFLAGS', '').split()
@@ -109,6 +108,7 @@ class CompileFortran(Step):
 
         """
         super().run(artefact_store, config)
+        logger.info(f'fortran compiler is {self.compiler} {self.compiler_version}')
 
         # get all the source to compile, for all build trees, into one big lump
         build_lists: Dict[str, List] = self.source_getter(artefact_store)

--- a/source/fab/steps/preprocess.py
+++ b/source/fab/steps/preprocess.py
@@ -61,7 +61,6 @@ class PreProcessor(Step):
         # Command line tools are sometimes specified with flags attached, e.g 'cpp -traditional-cpp'
         preprocessor_split = (preprocessor or os.getenv('FPP', 'fpp -P')).split()  # type: ignore
         self.preprocessor = preprocessor_split[0]
-        logger.info(f'preprocessor for {self.name} is {self.preprocessor}')
 
         common_flags = preprocessor_split[1:] + (common_flags or [])
         self.flags = FlagsConfig(common_flags=common_flags, path_flags=path_flags)
@@ -83,6 +82,7 @@ class PreProcessor(Step):
 
         """
         super().run(artefact_store, config)
+        logger.info(f'preprocessor for {self.name} is {self.preprocessor}')
 
         files = list(self.source_getter(artefact_store))
         logger.info(f'preprocessing {len(files)} files')


### PR DESCRIPTION
UM example config now works with ifort.

 - Removed the opt argument from our example um script because I think it differs between compilers and doesn't seem helpful right now.
 - Addresses part of #189 (i'll need help with the atm config, in a separate pr).
 - Moved a couple of steps' log lines from `__init__` to `run` because they were only going to the screen (the file logging handler is set up in run, and there's also [a ticket](https://github.com/orgs/metomi/projects/1/views/1?filterQuery=logg) to revisit the logging).