### PR TITLE
add ca-certificates to picasso

### DIFF
--- a/envs/picasso/image.yml
+++ b/envs/picasso/image.yml
@@ -12,6 +12,7 @@ conda:
     - mypy
     - matplotlib
     - rsync
+    - ca-certificates
 
 commands:
   - python3 setup.py install


### PR DESCRIPTION
add ca-certificates conda package to picasso image, hopefully to enable git clone to work.

todo:
 - [ ] did it work?
    - [ ] no, try binding to the cert file instead