### PR TITLE
Remove ignores for built documentation.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,7 +105,3 @@ venv.bak/
 
 # Profiler stats
 .pstats
-
-# apidoc generated output
-docs/build
-docs/source/apidoc


### PR DESCRIPTION
Looks like I didn't understand how the documentation generating workflow worked.