### PR TITLE
278 absolute paths in compilation

### DIFF
--- a/source/fab/steps/compile_fortran.py
+++ b/source/fab/steps/compile_fortran.py
@@ -363,7 +363,7 @@ def compile_file(analysed_file, flags, output_fpath, mp_common_args):
     command.append(str(analysed_file.fpath))
     command.extend(['-o', str(output_fpath)])
 
-    run_command(command, cwd=analysed_file.fpath.parent)
+    run_command(command)
 
 
 # todo: move this

--- a/source/fab/steps/compile_fortran.py
+++ b/source/fab/steps/compile_fortran.py
@@ -360,7 +360,7 @@ def compile_file(analysed_file, flags, output_fpath, mp_common_args):
         command.extend([known_compiler.module_folder_flag, str(mp_common_args.config.build_output)])
 
     # files
-    command.append(analysed_file.fpath.name)
+    command.append(str(analysed_file.fpath))
     command.extend(['-o', str(output_fpath)])
 
     run_command(command, cwd=analysed_file.fpath.parent)


### PR DESCRIPTION
A tiny tiny change to make the Fortran compilation use absolute paths, the same way c compilation does. Besides consistency, it's also easier to debug if you can copy&paste the compilation lines :)

Fixes #278.