### PR TITLE
Minor documentation update

### DIFF
--- a/docs/source/advanced_config.rst
+++ b/docs/source/advanced_config.rst
@@ -82,18 +82,20 @@ import your grab configuration to find out where it put the source.
 
     if __name__ == '__main__':
         with BuildConfig(project_label='<project_label>') as state:
-            grab_folder(state, src=grab_config.source_root),
+            grab_folder(state, src=my_grab_config.source_root),
 
 
 Housekeeping
 ============
 
-Fab will remove old files from the prebuilds folder. It will remove all prebuild files that are not part of the current build by default.
-
-If you add a :func:`~fab.steps.cleanup_prebuilds.cleanup_prebuilds` step, you
-can keep prebuild files for longer. This may be useful, for example, if you
-often switch between two versions of your code and want to keep the prebuild
-speed benefits when building both.
+You can add a :func:`~fab.steps.cleanup_prebuilds.cleanup_prebuilds`
+step, where you can explicitly control how long to keep prebuild files.
+This may be useful, for example, if you often switch between two versions
+of your code and want to keep the prebuild speed benefits when building
+both. If you do not add your own cleanup_prebuild step, Fab will
+automatically run a default step which will remove old files from the
+prebuilds folder. It will remove all prebuild files that are not part of
+the current build by default.
 
 
 Sharing Prebuilds

--- a/docs/source/environment.rst
+++ b/docs/source/environment.rst
@@ -3,11 +3,11 @@
 Environment
 ***********
 
-Fab requires a suitible Python environment in which to run. This page outlines
+Fab requires a suitable Python environment in which to run. This page outlines
 some routes to achieving such an environment.
 
 This page contains general instructions, there are additional instructions for
-:ref:`Met Office<MetOffice>` users elsewhere.
+:ref:`Met Office<MetOfficeUsage>` users elsewhere.
 
 
 .. _Requirements:

--- a/docs/source/writing_config.rst
+++ b/docs/source/writing_config.rst
@@ -236,14 +236,14 @@ However preprocessing C currently requires a preceding step called the
 into the C code so Fab is able to deduce which inclusions are user code and
 which are system code. This allows system dependencies to be ignored.
 
-See also :ref:`Advanced C Code<Advanced C Code>`
+See also :ref:`Advanced C Code<C Pragma Injector>`
 
 
 Further Reading
 ===============
 
 More advanced configuration topics are discussed in
-:ref:`Advanced Configuration`.
+:ref:`Advanced Config`.
 
 You can see more complicated configurations in the
 `developer testing directory <https://github.com/metomi/fab/tree/master/run_configs>`_.

--- a/source/fab/steps/compile_fortran.py
+++ b/source/fab/steps/compile_fortran.py
@@ -67,7 +67,7 @@ def compile_fortran(config: BuildConfig, common_flags: Optional[List[str]] = Non
         A list of :class:`~fab.build_config.AddFlags`, defining flags to be included in the command line call
         for selected files.
     :param source:
-        An :class:`~fab.artefacts.ArtefactsGetter` which give us our c files to process.
+        An :class:`~fab.artefacts.ArtefactsGetter` which gives us our Fortran files to process.
 
     """
 

--- a/tests/system_tests/psyclone/skeleton/algorithm/algorithm_mod.x90
+++ b/tests/system_tests/psyclone/skeleton/algorithm/algorithm_mod.x90
@@ -46,7 +46,7 @@ contains
     ! Set the new field to a constant value and compute the divergence of it
     divergence => get_div()
     s = 2.0_r_def
-    call invoke( name = "Compute divergence",  &
+    call invoke( name = "Compute_divergence",  &
                  setval_c(field_2, s        ), &
                  setval_c(field_1, 0.0_r_def), &
                  my_kernel_type(field_1, field_2, divergence) )

--- a/tests/system_tests/psyclone/test_psyclone.py
+++ b/tests/system_tests/psyclone/test_psyclone.py
@@ -5,6 +5,7 @@
 # ##############################################################################
 import filecmp
 import shutil
+import glob
 from os import unlink
 from pathlib import Path
 from unittest import mock
@@ -160,17 +161,17 @@ class TestPsyclone(object):
             config.build_output / 'algorithm/algorithm_mod_psy.f90',
 
             # Expect these prebuild files
-            # todo: the kernal hash differs between fpp and cpp, perhaps just use wildcards.
-            config.prebuild_folder / 'algorithm_mod.1602753696.an',  # x90 analysis result
-            config.prebuild_folder / 'my_kernel_mod.4187107526.an',  # kernel analysis results
-            config.prebuild_folder / 'algorithm_mod.5088673431.f90',  # prebuild
-            config.prebuild_folder / 'algorithm_mod_psy.5088673431.f90',  # prebuild
+            # The kernel hash differs between fpp and cpp, so just use wildcards.
+            config.prebuild_folder / 'algorithm_mod.*.an',  # x90 analysis result
+            config.prebuild_folder / 'my_kernel_mod.*.an',  # kernel analysis results
+            config.prebuild_folder / 'algorithm_mod.*.f90',  # prebuild
+            config.prebuild_folder / 'algorithm_mod_psy.*.f90',  # prebuild
         ]
 
-        assert all(not f.exists() for f in expect_files)
+        assert all(not any(glob.glob(str(f))) for f in expect_files)
         with config:
             self.steps(config)
-        assert all(f.exists() for f in expect_files)
+        assert all(any(glob.glob(str(f))) for f in expect_files)
 
     def test_prebuild(self, tmp_path, config):
         with config:


### PR DESCRIPTION
Minor documentation fixes for #277. It additionally fixes all other broken links reported (I had to guess a bit where the 'advanced c code' link was supposed to go - please let me know if not to the pragma injector section.).

Fixes #277.