### PR TITLE
Streamline testing with tox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,10 @@ venv.bak/
 
 # Profiler stats
 .pstats
+
+# Sphinx documentation
+docs/build
+docs/source/apidoc
+
+# Psyclone test output
+tests/system_tests/psyclone/algorithm.parsable_x90

--- a/README.md
+++ b/README.md
@@ -24,3 +24,9 @@ You may simply use `pip install sci-fab`.
 Although Fab is in its initial development phases right now and much of the
 functionality is yet to be added, the command line interface to the tool is 
 in place and can be run using the command `fab` 
+
+## Testing
+
+The fab test suite and documentation can be tested using tox.  Install
+the command with `pip install tox` and then run the `tox` command to
+test and lint your working copy.

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,45 @@
+[tox]
+isolated_build = true
+min_version = 4.0
+env_list =
+    unit
+    system
+    type
+    flake8
+    docs
+
+[testenv]
+deps = pytest
+     pytest-cov
+     pytest-mock
+     fparser
+     libclang
+
+[testenv:{unit,system}]
+description = Run regression tests
+setenv = 
+       ignore = -W ignore::UserWarning \
+                 -W ignore::DeprecationWarning
+commands =
+         unit: pytest {posargs:{env:ignore:}} --cov=fab tests/unit_tests
+         system: pytest {posargs:{env:ignore:}} --cov=fab tests/system_tests
+
+[testenv:type]
+description = Check type hinting
+deps = mypy
+commands = mypy source
+
+[testenv:flake8]
+description = Run flake8 linting
+deps = flake8
+commands = flake8 --count --show-source --statistics source
+
+[testenv:docs]
+description = Build the documentation
+deps = sphinx
+     sphinx-material
+     sphinx-autodoc-typehints
+     sphinx-copybutton
+commands = 
+         sphinx-apidoc --separate --module-first -d 5 -f -o docs/source/apidoc source/fab
+         sphinx-build -M html docs/source docs/build


### PR DESCRIPTION
Add a tox configuration file and adjust the gitignore list to account for a few extra files created by the test suite.  This should streamline the process of testing changes from the command line.